### PR TITLE
Set request format to json by default and revamp error handling

### DIFF
--- a/openapi/worldbank/client.bal
+++ b/openapi/worldbank/client.bal
@@ -18,15 +18,7 @@ import  ballerina/http;
 import  ballerina/url;
 import  ballerina/lang.'string;
 
-public type CountryPopulationArr CountryPopulation[];
-
-public type GrossDomesticProductArr GrossDomesticProduct[];
-
-public type AccessToElectricityArr AccessToElectricity[];
-
-public type YouthLiteracyRateArr YouthLiteracyRate[];
-
-public type PrimaryEducationExpenditureArr PrimaryEducationExpenditure[];
+type JsonArr json[];
 
 # World Bank Data
 #
@@ -40,187 +32,187 @@ public client class Client {
     }
     # Get population of each country
     #
-    # + date - Date-range by year, month or quarter that scopes the result-set.
-    # + format - Format of the response.
+    # + date - Date by year (2010), Date-range by year(2005:2010), month(2010M02:2010M08) or quarter(2012Q1:2012Q3) that scopes the result-set.
     # + page - Page number
     # + per_page - Per page record count
     # + return - Population of each countries
     @display {label: "Get Population"}
-    remote isolated function getPopulation(@display {label: "Date"} string? date = (), @display {label: "Response Format"} string? format = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns CountryPopulationArr|error? {
+    remote isolated function getPopulation(@display {label: "Date"} string? date = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns CountryPopulation[]|error {
         string  path = string `/country/all/indicator/SP.POP.TOTL`;
-        map<anydata> queryParam = {date: date, format: format, page: page, per_page: per_page};
+        map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
-        http:Response httpResponse = check self.clientEp-> get(path);
-        json[] payload = <json[]> check httpResponse.getJsonPayload();
-        if (!(payload[1] is ())) {
-            return payload[1].cloneWithType(CountryPopulationArr);
+        json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
+        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
+            return payloadArr[1].cloneWithType();            
+        } else {
+            return [];
         }
     }
     # Get population of a country
     #
     # + country_code - Country code (Example- AFG, ALB, LKA)
-    # + date - Date-range by year, month or quarter that scopes the result-set.
-    # + format - Format of the response.
+    # + date - Date by year (2010), Date-range by year(2005:2010), month(2010M02:2010M08) or quarter(2012Q1:2012Q3) that scopes the result-set.
     # + page - Page number
     # + per_page - Per page record count
     # + return - Yearly population of the given country
     @display {label: "Get Country Population"}
-    remote isolated function getPopulationByCountry(@display {label: "Country Code"} string country_code, @display {label: "Date"} string date, @display {label: "Response Format"} string? format = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns CountryPopulationArr|error? {
+    remote isolated function getPopulationByCountry(@display {label: "Country Code"} string country_code, @display {label: "Date"} string date, @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns CountryPopulation[]|error {
         string  path = string `/country/${country_code}/indicator/SP.POP.TOTL`;
-        map<anydata> queryParam = {date: date, format: format, page: page, per_page: per_page};
+        map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
-        http:Response httpResponse = check self.clientEp-> get(path);
-        json[] payload = <json[]> check httpResponse.getJsonPayload();
-        if (!(payload[1] is ())) {
-            return payload[1].cloneWithType(CountryPopulationArr);
+        json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
+        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
+            return payloadArr[1].cloneWithType();            
+        } else {
+            return [];
         }
     }
     # Get GDP of each country.
     #
-    # + date - Date-range by year, month or quarter that scopes the result-set.
-    # + format - Format of the response.
+    # + date - Date by year (2010), Date-range by year(2005:2010), month(2010M02:2010M08) or quarter(2012Q1:2012Q3) that scopes the result-set.
     # + page - Page number
     # + per_page - Per page record count
     # + return - GDP of each country
     @display {label: "Get GDP"}
-    remote isolated function getGDP(string? date = (), @display {label: "Response Format"} string? format = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns GrossDomesticProductArr|error? {
+    remote isolated function getGDP(string? date = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns GrossDomesticProduct[]|error {
         string  path = string `/country/all/indicator/NY.GDP.MKTP.CD`;
-        map<anydata> queryParam = {date: date, format: format, page: page, per_page: per_page};
+        map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
-        http:Response httpResponse = check self.clientEp-> get(path);
-        json[] payload = <json[]> check httpResponse.getJsonPayload();
-        if (!(payload[1] is ())) {
-            return payload[1].cloneWithType(GrossDomesticProductArr);
+        json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
+        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
+            return payloadArr[1].cloneWithType();            
+        } else {
+            return [];
         }
     }
     # Get GDP of a country.
     #
     # + country_code - Country code (Example- AFG, ALB, LKA)
-    # + date - Date-range by year, month or quarter that scopes the result-set.
-    # + format - Format of the response.
+    # + date - Date by year (2010), Date-range by year(2005:2010), month(2010M02:2010M08) or quarter(2012Q1:2012Q3) that scopes the result-set.
     # + page - Page number
     # + per_page - Per page record count
     # + return - Yearly GDP of the given country
     @display {label: "Get GDP By Country"}
-    remote isolated function getGDPByCountry(@display {label: "Country Code"} string country_code, string? date = (), @display {label: "Response Format"} string? format = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns GrossDomesticProductArr|error? {
+    remote isolated function getGDPByCountry(@display {label: "Country Code"} string country_code, string? date = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns GrossDomesticProduct[]|error {
         string  path = string `/country/${country_code}/indicator/NY.GDP.MKTP.CD`;
-        map<anydata> queryParam = {date: date, format: format, page: page, per_page: per_page};
+        map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
-        http:Response httpResponse = check self.clientEp-> get(path);
-        json[] payload = <json[]> check httpResponse.getJsonPayload();
-        if (!(payload[1] is ())) {
-            return payload[1].cloneWithType(GrossDomesticProductArr);
+        json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
+        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
+            return payloadArr[1].cloneWithType();            
+        } else {
+            return [];
         }
     }
     # Get percentage of population with access to electricity of countries in the world.
     #
-    # + date - Date-range by year, month or quarter that scopes the result-set.
-    # + format - Format of the response.
+    # + date - Date by year (2010), Date-range by year(2005:2010), month(2010M02:2010M08) or quarter(2012Q1:2012Q3) that scopes the result-set.
     # + page - Page number
     # + per_page - Per page record count
     # + return - Population percentage having electricity of each country.
     @display {label: "Get Population% Having Electricity"}
-    remote isolated function getAccessToElectricityPercentage(string? date = (), @display {label: "Response Format"} string? format = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns AccessToElectricityArr|error? {
+    remote isolated function getAccessToElectricityPercentage(string? date = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns AccessToElectricity[]|error {
         string  path = string `/country/all/indicator/1.1_ACCESS.ELECTRICITY.TOT`;
-        map<anydata> queryParam = {date: date, format: format, page: page, per_page: per_page};
+        map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
-        http:Response httpResponse = check self.clientEp-> get(path);
-        json[] payload = <json[]> check httpResponse.getJsonPayload();
-        if (!(payload[1] is ())) {
-            return payload[1].cloneWithType(AccessToElectricityArr);
+        json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
+        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
+            return payloadArr[1].cloneWithType();            
+        } else {
+            return [];
         }
     }
     # Get percentage of population with access to electricity of a given country.
     #
     # + country_code - Country code (Example- AFG, ALB, LKA)
-    # + date - Date-range by year, month or quarter that scopes the result-set.
-    # + format - Format of the response.
+    # + date - Date by year (2010), Date-range by year(2005:2010), month(2010M02:2010M08) or quarter(2012Q1:2012Q3) that scopes the result-set.
     # + page - Page number
     # + per_page - Per page record count
     # + return - Yearly population percentage having electricity of the given country.
     @display {label: "Get Population% Having Electricity By Country"}
-    remote isolated function getAccessToElectricityPercentageByCountry(@display {label: "Country Code"} string country_code, string? date = (), @display {label: "Response Format"} string? format = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns AccessToElectricityArr|error? {
+    remote isolated function getAccessToElectricityPercentageByCountry(@display {label: "Country Code"} string country_code, string? date = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns AccessToElectricity[]|error {
         string  path = string `/country/${country_code}/indicator/1.1_ACCESS.ELECTRICITY.TOT`;
-        map<anydata> queryParam = {date: date, format: format, page: page, per_page: per_page};
+        map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
-        http:Response httpResponse = check self.clientEp-> get(path);
-        json[] payload = <json[]> check httpResponse.getJsonPayload();
-        if (!(payload[1] is ())) {
-            return payload[1].cloneWithType(AccessToElectricityArr);
+        json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
+        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
+            return payloadArr[1].cloneWithType();            
+        } else {
+            return [];
         }
     }
     # Get literacy rate of youth (% of people ages 15-24) of countries in the world.
     #
-    # + date - Date-range by year, month or quarter that scopes the result-set.
-    # + format - Format of the response.
+    # + date - Date by year (2010), Date-range by year(2005:2010), month(2010M02:2010M08) or quarter(2012Q1:2012Q3) that scopes the result-set.
     # + page - Page number
     # + per_page - Per page record count
     # + return - Youth literacy rate of each country.
     @display {label: "Get Youth Literacy Rate"}
-    remote isolated function getYouthLiteracyRate(@display {label: "Date"} string? date = (), @display {label: "Response Format"} string? format = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns YouthLiteracyRateArr|error? {
+    remote isolated function getYouthLiteracyRate(@display {label: "Date"} string? date = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns YouthLiteracyRate[]|error {
         string  path = string `/country/all/indicator/1.1_YOUTH.LITERACY.RATE`;
-        map<anydata> queryParam = {date: date, format: format, page: page, per_page: per_page};
+        map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
-        http:Response httpResponse = check self.clientEp-> get(path);
-        json[] payload = <json[]> check httpResponse.getJsonPayload();
-        if (!(payload[1] is ())) {
-            return payload[1].cloneWithType(YouthLiteracyRateArr);
+        json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
+        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
+            return payloadArr[1].cloneWithType();            
+        } else {
+            return [];
         }
     }
     # Get literacy rate of youth (% of people ages 15-24) of a country.
     #
     # + country_code - Country code (Example- AFG, ALB, LKA)
-    # + date - Date-range by year, month or quarter that scopes the result-set.
-    # + format - Format of the response.
+    # + date - Date by year (2010), Date-range by year(2005:2010), month(2010M02:2010M08) or quarter(2012Q1:2012Q3) that scopes the result-set.
     # + page - Page number
     # + per_page - Per page record count
     # + return - Youth literacy rate of the given country.
     @display {label: "Get Youth Literacy Rate By Country"}
-    remote isolated function getYouthLiteracyRateByCountry(@display {label: "Country Code"} string country_code, @display {label: "Date"} string? date = (), @display {label: "Response Format"} string? format = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns YouthLiteracyRateArr|error? {
+    remote isolated function getYouthLiteracyRateByCountry(@display {label: "Country Code"} string country_code, @display {label: "Date"} string? date = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns YouthLiteracyRate[]|error {
         string  path = string `/country/${country_code}/indicator/1.1_YOUTH.LITERACY.RATE`;
-        map<anydata> queryParam = {date: date, format: format, page: page, per_page: per_page};
+        map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
-        http:Response httpResponse = check self.clientEp-> get(path);
-        json[] payload = <json[]> check httpResponse.getJsonPayload();
-        if (!(payload[1] is ())) {
-            return payload[1].cloneWithType(YouthLiteracyRateArr);
+        json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
+        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
+            return payloadArr[1].cloneWithType();            
+        } else {
+            return [];
         }
     }
     # Get government expenditure on primary education of each country
     #
-    # + date - Date-range by year, month or quarter that scopes the result-set.
-    # + format - Format of the response.
+    # + date - Date by year (2010), Date-range by year(2005:2010), month(2010M02:2010M08) or quarter(2012Q1:2012Q3) that scopes the result-set.
     # + page - Page number
     # + per_page - Per page record count
     # + return - Government expenditure on primary education of each country.
     @display {label: "Get Government Expenditure On Education"}
-    remote isolated function getGovernmentExpenditureOnPrimaryEducation(@display {label: "Date"} string? date = (), @display {label: "Response Format"} string? format = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns PrimaryEducationExpenditureArr|error? {
+    remote isolated function getGovernmentExpenditureOnPrimaryEducation(@display {label: "Date"} string? date = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns PrimaryEducationExpenditure[]|error {
         string  path = string `/country/all/indicator/UIS.X.PPP.1.FSGOV`;
-        map<anydata> queryParam = {date: date, format: format, page: page, per_page: per_page};
+        map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
-        http:Response httpResponse = check self.clientEp-> get(path);
-        json[] payload = <json[]> check httpResponse.getJsonPayload();
-        if (!(payload[1] is ())) {
-            return payload[1].cloneWithType(PrimaryEducationExpenditureArr);
+        json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
+        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
+            return payloadArr[1].cloneWithType();            
+        } else {
+            return [];
         }
     }
     # Get government expenditure on primary education of a country.
     #
     # + country_code - Country code (Example- AFG, ALB, LKA)
-    # + date - Date-range by year, month or quarter that scopes the result-set.
-    # + format - Format of the response.
+    # + date - Date by year (2010), Date-range by year(2005:2010), month(2010M02:2010M08) or quarter(2012Q1:2012Q3) that scopes the result-set.
     # + page - Page number
     # + per_page - Per page record count
     # + return - Government expenditure on primary education of a country.
     @display {label: "Get Government Expenditure On Education By Country"}
-    remote isolated function getGovernmentExpenditureOnPrimaryEducationByCountry(@display {label: "Country Code"} string country_code, @display {label: "Date"} string? date = (), @display {label: "Response Format"} string? format = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns PrimaryEducationExpenditureArr|error? {
+    remote isolated function getGovernmentExpenditureOnPrimaryEducationByCountry(@display {label: "Country Code"} string country_code, @display {label: "Date"} string? date = (), @display {label: "Page Number"} int? page = (), @display {label: "Per Page Record Count"} int? per_page = ()) returns PrimaryEducationExpenditure[]|error {
         string  path = string `/country/${country_code}/indicator/UIS.X.PPP.1.FSGOV`;
-        map<anydata> queryParam = {date: date, format: format, page: page, per_page: per_page};
+        map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
-        http:Response httpResponse = check self.clientEp-> get(path);
-        json[] payload = <json[]> check httpResponse.getJsonPayload();
-        if (!(payload[1] is ())) {
-            return payload[1].cloneWithType(PrimaryEducationExpenditureArr);
+        json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
+        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
+            return payloadArr[1].cloneWithType();            
+        } else {
+            return [];
         }
     }
 }

--- a/openapi/worldbank/client.bal
+++ b/openapi/worldbank/client.bal
@@ -20,6 +20,16 @@ import  ballerina/lang.'string;
 
 type JsonArr json[];
 
+type ErrorResponse record {
+    ErrorMessage[] message;
+};
+
+type ErrorMessage record {
+    string id;
+    string 'key;
+    string value;
+};
+
 # World Bank Data
 #
 # + clientEp - Connector http endpoint
@@ -42,10 +52,20 @@ public client class Client {
         map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
         json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
-        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
-            return payloadArr[1].cloneWithType();            
+        if (payloadArr.length() > 1) {
+            if (payloadArr[1] != ()) {
+                return payloadArr[1].cloneWithType(); 
+            } else {
+                return [];
+            }
         } else {
-            return [];
+            ErrorResponse|error errorResponse = payloadArr[0].cloneWithType(ErrorResponse);
+            if (errorResponse is ErrorResponse) {
+                ErrorMessage[] errorMessage = errorResponse.message;
+                return error(errorMessage[0].value, id = errorMessage[0].id, key = errorMessage[0].key);
+            } else {
+                return error("Invalid Request");
+            }    
         }
     }
     # Get population of a country
@@ -61,10 +81,20 @@ public client class Client {
         map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
         json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
-        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
-            return payloadArr[1].cloneWithType();            
+        if (payloadArr.length() > 1) {
+            if (payloadArr[1] != ()) {
+                return payloadArr[1].cloneWithType(); 
+            } else {
+                return [];
+            }
         } else {
-            return [];
+            ErrorResponse|error errorResponse = payloadArr[0].cloneWithType(ErrorResponse);
+            if (errorResponse is ErrorResponse) {
+                ErrorMessage[] errorMessage = errorResponse.message;
+                return error(errorMessage[0].value, id = errorMessage[0].id, key = errorMessage[0].key);
+            } else {
+                return error("Invalid Request");
+            }           
         }
     }
     # Get GDP of each country.
@@ -79,10 +109,20 @@ public client class Client {
         map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
         json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
-        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
-            return payloadArr[1].cloneWithType();            
+        if (payloadArr.length() > 1) {
+            if (payloadArr[1] != ()) {
+                return payloadArr[1].cloneWithType(); 
+            } else {
+                return [];
+            }
         } else {
-            return [];
+            ErrorResponse|error errorResponse = payloadArr[0].cloneWithType(ErrorResponse);
+            if (errorResponse is ErrorResponse) {
+                ErrorMessage[] errorMessage = errorResponse.message;
+                return error(errorMessage[0].value, id = errorMessage[0].id, key = errorMessage[0].key);
+            } else {
+                return error("Invalid Request");
+            }    
         }
     }
     # Get GDP of a country.
@@ -98,10 +138,20 @@ public client class Client {
         map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
         json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
-        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
-            return payloadArr[1].cloneWithType();            
+        if (payloadArr.length() > 1) {
+            if (payloadArr[1] != ()) {
+                return payloadArr[1].cloneWithType(); 
+            } else {
+                return [];
+            }
         } else {
-            return [];
+            ErrorResponse|error errorResponse = payloadArr[0].cloneWithType(ErrorResponse);
+            if (errorResponse is ErrorResponse) {
+                ErrorMessage[] errorMessage = errorResponse.message;
+                return error(errorMessage[0].value, id = errorMessage[0].id, key = errorMessage[0].key);
+            } else {
+                return error("Invalid Request");
+            }    
         }
     }
     # Get percentage of population with access to electricity of countries in the world.
@@ -116,10 +166,20 @@ public client class Client {
         map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
         json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
-        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
-            return payloadArr[1].cloneWithType();            
+        if (payloadArr.length() > 1) {
+            if (payloadArr[1] != ()) {
+                return payloadArr[1].cloneWithType(); 
+            } else {
+                return [];
+            }
         } else {
-            return [];
+            ErrorResponse|error errorResponse = payloadArr[0].cloneWithType(ErrorResponse);
+            if (errorResponse is ErrorResponse) {
+                ErrorMessage[] errorMessage = errorResponse.message;
+                return error(errorMessage[0].value, id = errorMessage[0].id, key = errorMessage[0].key);
+            } else {
+                return error("Invalid Request");
+            }    
         }
     }
     # Get percentage of population with access to electricity of a given country.
@@ -135,10 +195,20 @@ public client class Client {
         map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
         json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
-        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
-            return payloadArr[1].cloneWithType();            
+        if (payloadArr.length() > 1) {
+            if (payloadArr[1] != ()) {
+                return payloadArr[1].cloneWithType(); 
+            } else {
+                return [];
+            }
         } else {
-            return [];
+            ErrorResponse|error errorResponse = payloadArr[0].cloneWithType(ErrorResponse);
+            if (errorResponse is ErrorResponse) {
+                ErrorMessage[] errorMessage = errorResponse.message;
+                return error(errorMessage[0].value, id = errorMessage[0].id, key = errorMessage[0].key);
+            } else {
+                return error("Invalid Request");
+            }    
         }
     }
     # Get literacy rate of youth (% of people ages 15-24) of countries in the world.
@@ -153,10 +223,20 @@ public client class Client {
         map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
         json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
-        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
-            return payloadArr[1].cloneWithType();            
+        if (payloadArr.length() > 1) {
+            if (payloadArr[1] != ()) {
+                return payloadArr[1].cloneWithType(); 
+            } else {
+                return [];
+            }
         } else {
-            return [];
+            ErrorResponse|error errorResponse = payloadArr[0].cloneWithType(ErrorResponse);
+            if (errorResponse is ErrorResponse) {
+                ErrorMessage[] errorMessage = errorResponse.message;
+                return error(errorMessage[0].value, id = errorMessage[0].id, key = errorMessage[0].key);
+            } else {
+                return error("Invalid Request");
+            }    
         }
     }
     # Get literacy rate of youth (% of people ages 15-24) of a country.
@@ -172,10 +252,20 @@ public client class Client {
         map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
         json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
-        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
-            return payloadArr[1].cloneWithType();            
+        if (payloadArr.length() > 1) {
+            if (payloadArr[1] != ()) {
+                return payloadArr[1].cloneWithType(); 
+            } else {
+                return [];
+            }
         } else {
-            return [];
+            ErrorResponse|error errorResponse = payloadArr[0].cloneWithType(ErrorResponse);
+            if (errorResponse is ErrorResponse) {
+                ErrorMessage[] errorMessage = errorResponse.message;
+                return error(errorMessage[0].value, id = errorMessage[0].id, key = errorMessage[0].key);
+            } else {
+                return error("Invalid Request");
+            }    
         }
     }
     # Get government expenditure on primary education of each country
@@ -190,10 +280,20 @@ public client class Client {
         map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
         json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
-        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
-            return payloadArr[1].cloneWithType();            
+        if (payloadArr.length() > 1) {
+            if (payloadArr[1] != ()) {
+                return payloadArr[1].cloneWithType(); 
+            } else {
+                return [];
+            }
         } else {
-            return [];
+            ErrorResponse|error errorResponse = payloadArr[0].cloneWithType(ErrorResponse);
+            if (errorResponse is ErrorResponse) {
+                ErrorMessage[] errorMessage = errorResponse.message;
+                return error(errorMessage[0].value, id = errorMessage[0].id, key = errorMessage[0].key);
+            } else {
+                return error("Invalid Request");
+            }    
         }
     }
     # Get government expenditure on primary education of a country.
@@ -209,10 +309,20 @@ public client class Client {
         map<anydata> queryParam = {date: date, format: "json", page: page, per_page: per_page};
         path = path + getPathForQueryParam(queryParam);
         json[] payloadArr = check self.clientEp-> get(path, targetType = JsonArr);
-        if (payloadArr.length() > 1 && payloadArr[1] != ()) {
-            return payloadArr[1].cloneWithType();            
+        if (payloadArr.length() > 1) {
+            if (payloadArr[1] != ()) {
+                return payloadArr[1].cloneWithType(); 
+            } else {
+                return [];
+            }
         } else {
-            return [];
+            ErrorResponse|error errorResponse = payloadArr[0].cloneWithType(ErrorResponse);
+            if (errorResponse is ErrorResponse) {
+                ErrorMessage[] errorMessage = errorResponse.message;
+                return error(errorMessage[0].value, id = errorMessage[0].id, key = errorMessage[0].key);
+            } else {
+                return error("Invalid Request");
+            }    
         }
     }
 }


### PR DESCRIPTION
## Purpose
* Set request format to json by default and not allow for users to configure the request type
* Handle failures when error payload or empty payload was received

## Goals
* Return empty array when invalid payload was received
* All the responses from the WorldBank API endpoint will be in json format 