### PR TITLE
Add fields to an empty record in Zoom Connector

### DIFF
--- a/openapi/zoom/openapi.yaml
+++ b/openapi/zoom/openapi.yaml
@@ -2914,60 +2914,59 @@ components:
         meetings:
           description: List of Meeting objects.
           items:
-            allOf:
-              - properties:
-                  agenda:
-                    description: Meeting description. The length of agenda gets truncated to 250
-                      characters when you list all meetings for a user. To
-                      view the complete agenda of a meeting, retrieve
-                      details for a single meeting
-                      [here](https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meeting).
-                    type: string
-                  created_at:
-                    description: "Time of creation. "
-                    format: date-time
-                    type: string
-                  duration:
-                    description: Meeting duration.
-                    type: integer
-                  host_id:
-                    description: ID of the user who is set as the host of the meeting.
-                    type: string
-                  id:
-                    description: Meeting ID - also known as the meeting number in double (int64)
-                      format.
-                    format: int64
-                    type: integer
-                  join_url:
-                    description: Join URL.
-                    type: string
-                  start_time:
-                    description: Meeting start time.
-                    format: date-time
-                    type: string
-                  timezone:
-                    description: "Timezone to format the meeting start time. "
-                    type: string
-                  topic:
-                    description: Meeting topic.
-                    type: string
-                  type:
-                    description: "Meeting Type: 1 - Instant meeting. 2 - Scheduled meeting. 3 - Recurring meeting with no fixed time. 8 - Recurring meeting with fixed time."
-                    enum:
-                      - 1
-                      - 2
-                      - 3
-                      - 8
-                    type: integer
-                    x-enum-descriptions:
-                      - Instant Meeting
-                      - Scheduled Meeting
-                      - Recurring Meeting with no fixed time
-                      - Recurring Meeting with fixed time
-                  uuid:
-                    description: Unique Meeting ID. Each meeting instance will generate its own
-                      Meeting UUID.
-                    type: string
+            properties:
+                agenda:
+                  description: Meeting description. The length of agenda gets truncated to 250
+                    characters when you list all meetings for a user. To
+                    view the complete agenda of a meeting, retrieve
+                    details for a single meeting
+                    [here](https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meeting).
+                  type: string
+                created_at:
+                  description: "Time of creation. "
+                  format: date-time
+                  type: string
+                duration:
+                  description: Meeting duration.
+                  type: integer
+                host_id:
+                  description: ID of the user who is set as the host of the meeting.
+                  type: string
+                id:
+                  description: Meeting ID - also known as the meeting number in double (int64)
+                    format.
+                  format: int64
+                  type: integer
+                join_url:
+                  description: Join URL.
+                  type: string
+                start_time:
+                  description: Meeting start time.
+                  format: date-time
+                  type: string
+                timezone:
+                  description: "Timezone to format the meeting start time. "
+                  type: string
+                topic:
+                  description: Meeting topic.
+                  type: string
+                type:
+                  description: "Meeting Type: 1 - Instant meeting. 2 - Scheduled meeting. 3 - Recurring meeting with no fixed time. 8 - Recurring meeting with fixed time."
+                  enum:
+                    - 1
+                    - 2
+                    - 3
+                    - 8
+                  type: integer
+                  x-enum-descriptions:
+                    - Instant Meeting
+                    - Scheduled Meeting
+                    - Recurring Meeting with no fixed time
+                    - Recurring Meeting with fixed time
+                uuid:
+                  description: Unique Meeting ID. Each meeting instance will generate its own
+                    Meeting UUID.
+                  type: string
             type: object
           type: array
     MeetingPartcipantsList:

--- a/openapi/zoom/types.bal
+++ b/openapi/zoom/types.bal
@@ -75,7 +75,18 @@ public type RegistrantBaseObject record {
 # List of meetings
 public type MeetingList record {
     # List of Meeting objects.
-    record {}[] meetings?;
+    record  { # Meeting description. The length of agenda gets truncated to 250 characters when you list all meetings for a user. To view the complete agenda of a meeting, retrieve details for a single meeting [here](https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meeting).
+        string agenda?; # Time of creation. 
+        string created_at?; # Meeting duration.
+        int duration?; # ID of the user who is set as the host of the meeting.
+        string host_id?; # Meeting ID - also known as the meeting number in double (int64) format.
+        int id?; # Join URL.
+        string join_url?; # Meeting start time.
+        string start_time?; # Timezone to format the meeting start time. 
+        string timezone?; # Meeting topic.
+        string topic?; # Meeting Type: 1 - Instant meeting. 2 - Scheduled meeting. 3 - Recurring meeting with no fixed time. 8 - Recurring meeting with fixed time.
+        int 'type?; # Unique Meeting ID. Each meeting instance will generate its own Meeting UUID.
+        string uuid?;} [] meetings?;
 };
 
 # List of meeting participants


### PR DESCRIPTION
## Purpose
$subject

## Goals
There was an empty record generated without any fields due to an allOf related issue. Generated fields to that record by fixing the definition. 

