### PR TITLE
Fix post operation data mapping issue

### DIFF
--- a/openapi/medium/client.bal
+++ b/openapi/medium/client.bal
@@ -30,7 +30,8 @@ public type ClientConfig record {
 # + clientEp - Client for Medium API
 public client class Client {
     http:Client clientEp;
-    public isolated function init(ClientConfig clientConfig, string serviceUrl = "https://api.medium.com/v1") returns error? {
+    public isolated function init(ClientConfig clientConfig, string serviceUrl = "https://api.medium.com/v1") returns 
+                                  error? {
         http:ClientSecureSocket? secureSocketConfig = clientConfig?.secureSocketConfig;
         http:Client httpEp = check new (serviceUrl, { auth: clientConfig.authConfig, secureSocket: secureSocketConfig });
         self.clientEp = httpEp;
@@ -51,7 +52,8 @@ public client class Client {
     # + return - If success returns a list of publications that the user is subscribed to, writes to, or edits otherwise 
     # the relevant error
     @display {label: "Get Publication List"}
-    remote isolated function getPublicationList(@display {label: "User ID"} string userId) returns PublicationResponse|error {
+    remote isolated function getPublicationList(@display {label: "User ID"} string userId) returns PublicationResponse|
+                                                error {
         string  path = string `/users/${userId}/publications`;
         PublicationResponse response = check self.clientEp-> get(path, targetType = PublicationResponse);
         return response;
@@ -61,7 +63,8 @@ public client class Client {
     # + publicationId - A unique identifier for the publication.
     # + return - If success returns a list of contributors
     @display {label: "Get Contributor List"}
-    remote isolated function getContributorList(@display {label: "Publication ID"} string publicationId) returns ContributorResponse|error {
+    remote isolated function getContributorList(@display {label: "Publication ID"} string publicationId) returns 
+                                                ContributorResponse|error {
         string  path = string `/publications/${publicationId}/contributors`;
         ContributorResponse response = check self.clientEp-> get(path, targetType = ContributorResponse);
         return response;
@@ -73,12 +76,14 @@ public client class Client {
     # + return - If success returns a Post record that includes the newly created post detail otherwise the relevant
     #  error
     @display {label: "Create Post"}
-    remote isolated function createUserPost(@display {label: "User ID"} string authorId, @display {label: "Post Detail"} Post payload) returns PostDetails|error {
+    remote isolated function createUserPost(@display {label: "User ID"} string authorId, 
+                                            @display {label: "Post Detail"} Post payload) returns 
+                                            PostResponse|error {
         string  path = string `/users/${authorId}/posts`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
         request.setPayload(jsonBody);
-        PostDetails response = check self.clientEp->post(path, request, targetType=PostDetails);
+        PostResponse response = check self.clientEp->post(path, request, targetType=PostResponse);
         return response;
     }
 }

--- a/openapi/medium/openapi.yaml
+++ b/openapi/medium/openapi.yaml
@@ -110,7 +110,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostDetails'
+                $ref: '#/components/schemas/PostResponse'
         400:
           description: Required fields were invalid, not specified.
           content: {}
@@ -127,6 +127,13 @@ paths:
       x-codegen-request-body-name: body
 components:
   schemas:
+    PostResponse:
+      title: Post response
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/PostDetails'
+      description: Container object for post info
     UserResponse:
       title: User Container
       type: object
@@ -355,7 +362,7 @@ components:
           type: string
           description: The publish status of the post.
         publishedAt:
-          type: string
+          type: integer
           description: The post’s published date. If created as a draft, this field
             will not be present.
           format: date

--- a/openapi/medium/types.bal
+++ b/openapi/medium/types.bal
@@ -52,24 +52,30 @@ public type PostDetails record {
     string[] tags?;
     # The URL of the post on Medium
     string url?;
-    # The canonical URL of the post. If canonicalUrl was not specified in the creation of the post, this field will not be present.
+    # The canonical URL of the post. If canonicalUrl was not specified in the creation of the post, this field will not 
+    #be present.
     string canonicalUrl?;
     # The publish status of the post.
     string publishStatus?;
     # The post’s published date. If created as a draft, this field will not be present.
-    string publishedAt?;
+    int publishedAt?;
     # The license of the post.
-    string license?;
+    string? license?;
     # The URL to the license of the post.
-    string licenseUrl?;
+    string? licenseUrl?;
 };
 
 public type Post record {
-    # The title of the post. Note that this title is used for SEO and when rendering the post as a listing, but will not appear in the actual post—for that, the title must be specified in the content field as well. Titles longer than 100 characters will be ignored. In that case, a title will be synthesized from the first content in the post when it is published.
+    # The title of the post. Note that this title is used for SEO and when rendering the post as a listing, but will not 
+    # appear in the actual post—for that, the title must be specified in the content field as well. Titles longer than 
+    # 100 characters will be ignored. In that case, a title will be synthesized from the first content in the post when 
+    # it is published.
     string title;
     # The format of the "content" field. There are two valid values, "html", and "markdown"
     string contentFormat;
-    # The body of the post, in a valid, semantic, HTML fragment, or Markdown. Further markups may be supported in the future. For a full list of accepted HTML tags, see here. If you want your title to appear on the post page, you must also include it as part of the post content.
+    # The body of the post, in a valid, semantic, HTML fragment, or Markdown. Further markups may be supported in the 
+    # future. For a full list of accepted HTML tags, see here. If you want your title to appear on the post page, you 
+    # must also include it as part of the post content.
     string content;
     # Tags to classify the post. Only the first three will be used. Tags longer than 25 characters will be ignored.
     string[] tags?;
@@ -77,11 +83,14 @@ public type Post record {
     string canonicalUrl?;
     # The status of the post. Valid values are `public`, `draft`, or `unlisted`. The default is `public`.
     string publishStatus?;
-    # The license of the post. Valid values are `all-rights-reserved`, `cc-40-by`, `cc-40-by-sa`, `cc-40-by-nd`, `cc-40-by-nc`, `cc-40-by-nc-nd`, `cc-40-by-nc-sa`, `cc-40-zero`, `public-domain`. The default is `all-rights-reserved`.
+    # The license of the post. Valid values are `all-rights-reserved`, `cc-40-by`, `cc-40-by-sa`, `cc-40-by-nd`, 
+    # `cc-40-by-nc`, `cc-40-by-nc-nd`, `cc-40-by-nc-sa`, `cc-40-zero`, `public-domain`. The default is 
+    # `all-rights-reserved`.
     string license?;
 };
 
-# Publications provide a way for authors to work collaboratively within a common narrative framework, brand or point of view.
+# Publications provide a way for authors to work collaboratively within a common narrative framework, brand or point of 
+# view.
 public type Publication record {
     # A unique identifier for the publication.
     string id?;
@@ -109,4 +118,10 @@ public type Contributor record {
 public type PublicationResponse record {
     #An array of Publications
     Publication[] data?;
+};
+
+# Container object for post info
+public type PostResponse record {
+    # Details of Post
+    PostDetails data?;
 };


### PR DESCRIPTION
## Purpose
Fixing the connector return type "PostDetails"  data mapping issue

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 11, Ballerina Swan Lake Alpha5
