### PR TITLE
Add dependency locks for Bitbucket and Medium

### DIFF
--- a/openapi/bitbucket/Dependencies.toml
+++ b/openapi/bitbucket/Dependencies.toml
@@ -1,0 +1,9 @@
+[[dependency]]
+org = "ballerina"
+name = "http"
+version = "1.1.0-alpha8"
+
+[[dependency]]
+org = "ballerina"
+name = "url"
+version = "1.1.0-alpha8"

--- a/openapi/medium/Dependencies.toml
+++ b/openapi/medium/Dependencies.toml
@@ -1,0 +1,4 @@
+[[dependency]]
+org = "ballerina"
+name = "http"
+version = "1.1.0-alpha8"


### PR DESCRIPTION
## Purpose
Adding dependencies locking for the connectors: bitbucket, medium

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 11, Ballerina Swan Lake Alpha5
