### PR TITLE
Update dependencies in News API connector to Swan Lake Beta 2 and update documentations

### DIFF
--- a/openapi/newsapi/Ballerina.toml
+++ b/openapi/newsapi/Ballerina.toml
@@ -3,7 +3,7 @@ license = ["Apache-2.0"]
 keywords = ["News API", "Headlines", "Articles", "News"]
 org = "ballerinax"
 name = "newsapi"
-version = "0.1.1"
+version = "0.1.0-SANPSHOT"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/newsapi/Dependencies.toml
+++ b/openapi/newsapi/Dependencies.toml
@@ -1,11 +1,9 @@
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-alpha8"
+version = "1.1.0-beta.2"
 
 [[dependency]]
 org = "ballerina"
 name = "url"
-version = "1.1.0-alpha8"
-
-
+version = "1.1.0-beta.2"

--- a/openapi/newsapi/Module.md
+++ b/openapi/newsapi/Module.md
@@ -10,7 +10,7 @@ News API connector consume the data exposed in https://newsapi.org/v2. It is sup
 
 ### Prerequisites
 
-	* News API Account
+- News API Account
 
 ### Obtaining tokens
 
@@ -58,8 +58,7 @@ newsapi:Client myclient = check new newsapi:Client(config, {}, "https://newsapi.
 ```
 #### Step 3: Get top headlines
 ```ballerina
-    newsapi:WSNewsTopHeadlineResponse result = check myclient->listTopHeadlines(country="us");
-    log:printInfo(result.toString());
+newsapi:WSNewsTopHeadlineResponse result = check myclient->listTopHeadlines(country="us");
 ```
 
 ## Snippets
@@ -67,16 +66,13 @@ Snippets of some operations.
 
 ### Get top articles
 ```ballerina
-    newsapi:WSNewsTopHeadlineResponse articleResult = check myclient->listArticles(1, 5, domains="bbc.co.uk");
-    log:printInfo(articleResult.toString());    
+newsapi:WSNewsTopHeadlineResponse articleResult = check myclient->listArticles(1, 5, domains="bbc.co.uk");
 ```
 ### Get top headlines
 ```ballerina
-    newsapi:WSNewsTopHeadlineResponse result = check myclient->listTopHeadlines(country="us");
-    log:printInfo(result.toString());
+newsapi:WSNewsTopHeadlineResponse result = check myclient->listTopHeadlines(country="us");
 ```
 ### Get sources
 ```ballerina
-    newsapi:WSNewsSourcesResponse result = check myclient->listSources(country="us");
-    log:printInfo(result.toString());
+newsapi:WSNewsSourcesResponse result = check myclient->listSources(country="us");
 ```

--- a/openapi/newsapi/Module.md
+++ b/openapi/newsapi/Module.md
@@ -1,0 +1,82 @@
+## Overview
+
+News API connector consume the data exposed in https://newsapi.org/v2. It is supporting the following operations.
+
+- listArticles
+- listTopHeadlines
+- listSources
+
+## Obtaining tokens
+
+### Prerequisites
+
+	* News API Account
+
+### Obtaining tokens
+
+To utilize News API users have to obtain API key given by [News API](https://newsapi.org/register)
+
+To obtain an API Key please follow these steps
+    * Go to [News API](https://newsapi.org/) and register a new account
+    * Submit information in register form
+    * After submitting needed information API Key can be obtained
+
+Then provide the obtained API Key in client configuration.
+
+## Quickstart
+
+### Authorization
+
+To utilize News API users have to obtain API key given by [News API](https://newsapi.org/register)
+
+To obtain an API Key please follow these steps
+* Go to [News API](https://newsapi.org/) and register a new account
+* Submit information in register form
+* After submitting needed information API Key can be obtained
+
+Then provide the obtained API Key in client configuration.
+
+## Snippets
+
+### Client configuration
+
+#### Step 1: Import News API module
+First, import the ballerinax/newsapi module into the Ballerina project.
+
+```ballerina
+import ballerinax/newsapi;
+```
+#### Step 2: Configure the connection credentials.
+```ballerina
+newsapi:ApiKeysConfig config = {
+    apiKeys : {
+        apiKey : "<your apiKey>"
+    }
+};
+
+newsapi:Client myclient = check new newsapi:Client(config, {}, "https://newsapi.org/v2");
+```
+#### Step 3: Get top headlines
+```ballerina
+    newsapi:WSNewsTopHeadlineResponse result = check myclient->listTopHeadlines(country="us");
+    log:printInfo(result.toString());
+```
+
+## Snippets
+Snippets of some operations.
+
+### Get top articles
+```ballerina
+    newsapi:WSNewsTopHeadlineResponse articleResult = check myclient->listArticles(1, 5, domains="bbc.co.uk");
+    log:printInfo(articleResult.toString());    
+```
+### Get top headlines
+```ballerina
+    newsapi:WSNewsTopHeadlineResponse result = check myclient->listTopHeadlines(country="us");
+    log:printInfo(result.toString());
+```
+### Get sources
+```ballerina
+    newsapi:WSNewsSourcesResponse result = check myclient->listSources(country="us");
+    log:printInfo(result.toString());
+```

--- a/openapi/newsapi/Package.md
+++ b/openapi/newsapi/Package.md
@@ -7,8 +7,8 @@ Connects to News API from Ballerina
 |       News API Version        |         **V2**        |
 
 ### Package Overview
-The <jira> is a [Ballerina](https://ballerina.io/) connector for Jira.
-This package provides the capability to easily access Jira.
+The <newsapi> is a [Ballerina](https://ballerina.io/) connector for News API.
+This package provides the capability to easily access News API.
 ### Report Issues
 To report bugs, request new features, start new discussions, view project boards, etc., go to the [Ballerina connector repository](link)
 ### Useful Links

--- a/openapi/newsapi/Package.md
+++ b/openapi/newsapi/Package.md
@@ -1,56 +1,17 @@
-Connects to News API from Ballerina.
+Connects to News API from Ballerina
 
-## Module Overview
+#### Compatibility
+|                               | Version               |
+|-------------------------------|-----------------------|
+| Ballerina Language Version    | **Swan Lake Alpha 5** |
+|       News API Version        |         **V2**        |
 
-News API connector consume the data exposed in https://newsapi.org/v2. It is currently supporting the following operations.
-
-- listArticles
-- listTopHeadlines
-- listSources
-
-## Compatibility
-
-| Ballerina Language Versions  |             News API              |
-|:----------------------------:|:---------------------------------:|
-|       Swan Lake Alpha 5      |                V2                 |
-
-# Quickstart
-
-## Authorization
-
-To utilize News API users have to obtain API key given by [News API](https://newsapi.org/register)
-
-To obtain an API Key please follow these steps
-* Go to [News API](https://newsapi.org/) and register a new account
-* Submit information in register form
-* After submitting needed information API Key can be obtained
-
-Then provide the obtained API Key in client configuration.
-
-### Client configuration
-
-```ballerina
-    import ballerinax/newsapi;
-
-    ApiKeysConfig config = {
-        apiKeys : {
-            apiKey : "<your apiKey>"
-        }
-    }
-
-    newsapi:Client myclient = check new newsapi:Client(config, {}, "https://newsapi.org/v2");
-};
-```
-### Get Top Headlines
-
-```ballerina
-    WSNewsTopHeadlineResponse result = check myclient->listTopHeadlines(country="us");
-    log:printInfo(result.toString());
-```
-
-### Get Top Articles
-
-```ballerina
-    WSNewsTopHeadlineResponse articleResult = check myclient->listArticles(1, 5, domains="bbc.co.uk");
-    log:printInfo(articleResult.toString());    
-```
+### Package Overview
+The <jira> is a [Ballerina](https://ballerina.io/) connector for Jira.
+This package provides the capability to easily access Jira.
+### Report Issues
+To report bugs, request new features, start new discussions, view project boards, etc., go to the [Ballerina connector repository](link)
+### Useful Links
+- Discuss code changes of the Ballerina project in [ballerina-dev@googlegroups.com](mailto:ballerina-dev@googlegroups.com).
+- Chat live with us via our [Slack channel](https://ballerina.io/community/slack/).
+- Post all technical questions on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag

--- a/openapi/newsapi/Package.md
+++ b/openapi/newsapi/Package.md
@@ -3,7 +3,7 @@ Connects to News API from Ballerina
 #### Compatibility
 |                               | Version               |
 |-------------------------------|-----------------------|
-| Ballerina Language Version    | **Swan Lake Alpha 5** |
+| Ballerina Language Version    |  **Swan Lake Beat 2** |
 |       News API Version        |         **V2**        |
 
 ### Package Overview

--- a/openapi/newsapi/Package.md
+++ b/openapi/newsapi/Package.md
@@ -3,11 +3,11 @@ Connects to News API from Ballerina
 #### Compatibility
 |                               | Version               |
 |-------------------------------|-----------------------|
-| Ballerina Language Version    |  **Swan Lake Beat 2** |
+| Ballerina Language Version    |  **Swan Lake Beta 2** |
 |       News API Version        |         **V2**        |
 
 ### Package Overview
-The <newsapi> is a [Ballerina](https://ballerina.io/) connector for News API.
+The `newsapi` is a [Ballerina](https://ballerina.io/) connector for News API.
 This package provides the capability to easily access News API.
 ### Report Issues
 To report bugs, request new features, start new discussions, view project boards, etc., go to the [Ballerina connector repository](link)


### PR DESCRIPTION
## Purpose
> Update dependencies to Swan Lake Beta 2 in News API connector Dependencies.toml
>  Update connector documentations