### PR TITLE
[SL Beta 2] Add missing license headers for vonage.numberinsight connector

### DIFF
--- a/openapi/vonage.numberinsight/client.bal
+++ b/openapi/vonage.numberinsight/client.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import  ballerina/http;
 import  ballerina/url;
 import  ballerina/lang.'string;

--- a/openapi/vonage.numberinsight/types.bal
+++ b/openapi/vonage.numberinsight/types.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 # Information about the network `number` is currently connected to.
 public type NiCurrentCarrierProperties record {
     # The [https://en.wikipedia.org/wiki/Mobile_country_code](https://en.wikipedia.org/wiki/Mobile_country_code) for the carrier`number` is associated with. Unreal numbers are marked as`unknown` and the request is rejected altogether if the number is impossible according to the [E.164](https://en.wikipedia.org/wiki/E.164) guidelines.


### PR DESCRIPTION
## Purpose
> Add missing license headers for vonage.numberinsight connector

## Goals
> Add missing license headers for vonage.numberinsight connector

## Approach
> Add missing license headers for vonage.numberinsight connector

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
JDK 11
SL Beta 2
Ubuntu 20.04