### PR TITLE
[SLbeta2] add ebay.compliance connector

### DIFF
--- a/openapi/ebay.compliance/.gitignore
+++ b/openapi/ebay.compliance/.gitignore
@@ -1,0 +1,2 @@
+target
+tests/**

--- a/openapi/ebay.compliance/Ballerina.toml
+++ b/openapi/ebay.compliance/Ballerina.toml
@@ -1,0 +1,11 @@
+[package]
+org = "ballerinax"
+name = "ebay.compliance"
+repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
+version = "0.1.0-SNAPSHOT"
+authors = ["Ballerina"]
+license = ["Apache-2.0"]
+keywords = ["ebay", "ecommerce"]
+
+[build-options]
+observabilityIncluded = true

--- a/openapi/ebay.compliance/Dependencies.toml
+++ b/openapi/ebay.compliance/Dependencies.toml
@@ -1,0 +1,11 @@
+[[dependency]]
+org = "ballerina"
+name = "http"
+version = "1.1.0-beta.2"
+
+[[dependency]]
+org = "ballerina"
+name = "url"
+version = "1.1.0-beta.2"
+
+

--- a/openapi/ebay.compliance/Module.md
+++ b/openapi/ebay.compliance/Module.md
@@ -1,0 +1,14 @@
+## Overview
+This is a generated connector for [eBay Compliance API v1.4.1](https://developer.ebay.com) OpenAPI specification.
+The Ebay Compliance API helps sellers keep their listings in compliance with eBay’s policies. 
+Use this API to identify for a given seller all listings that have violations. 
+A listing violation can cause a bad buyer experience and may also prevent sellers from updating the listing until the 
+violation has been corrected. 
+API Documentation is at https://developer.ebay.com/api-docs/sell/compliance/overview.html
+
+## Prerequisites
+Before using this connector in your Ballerina application, complete the following:
+
+* Create an ebay developer account
+* Obtain tokens- follow [this link](https://developer.ebay.com/api-docs/static/oauth-tokens.html)
+ 

--- a/openapi/ebay.compliance/Package.md
+++ b/openapi/ebay.compliance/Package.md
@@ -1,0 +1,19 @@
+Connects to [eBay Compliance API v1.4.1](https://developer.ebay.com) from Ballerina
+
+### Package overview
+The `ballerinax/eBay.compliance` is a [Ballerina](https://ballerina.io/) connector helps sellers keep their listings in compliance with eBay’s policies.
+This package enables retrieving listing violations for any eBay listings, regardless of which user interface, tool, or API was used to create those listings.
+
+#### Compatibility
+|                                   | Version                       |
+|-----------------------------------|-------------------------------|
+| Ballerina Language                | Ballerina Swan Lake Beta2     |
+| eBay Compliance API               | 1.4.1                         |
+
+### Report issues
+To report bugs, request new features, start new discussions, view project boards, etc., go to the [Ballerina connector repository](link)
+
+### Useful links
+- Discuss code changes of the Ballerina project in [ballerina-dev@googlegroups.com](mailto:ballerina-dev@googlegroups.com).
+- Chat live with us via our [Slack channel](https://ballerina.io/community/slack/).
+- Post all technical questions on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag

--- a/openapi/ebay.compliance/client.bal
+++ b/openapi/ebay.compliance/client.bal
@@ -1,0 +1,131 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/url;
+import ballerina/lang.'string;
+
+public type ClientConfig record {
+    http:BearerTokenConfig|http:OAuth2RefreshTokenGrantConfig authConfig;
+    http:ClientSecureSocket secureSocketConfig?;
+};
+
+# This is a generated connector for [eBay Compliance API v1.4.1](https://developer.ebay.com) OpenAPI specification.
+# 'Service for providing information to sellers about their listings being non-compliant, or at risk for becoming non-compliant, against eBay listing policies.'
+public isolated client class Client {
+    final http:Client clientEp;
+    # Gets invoked to initialize the `connector`.
+    # The connector initialization requires setting the API credentials.
+    # Create [eBay developer account](https://developer.ebay.com/join/) and obtain tokens by following [this guide](https://developer.ebay.com/api-docs/static/oauth-tokens.html).
+    #
+    # + clientConfig - The configurations to be used when initializing the `connector`
+    # + serviceUrl - URL of the target service
+    # + return - An error at the failure of client initialization
+    public isolated function init(ClientConfig clientConfig, string serviceUrl = "https://api.ebay.com/sell/compliance/v1") returns error? {
+        http:ClientSecureSocket? secureSocketConfig = clientConfig?.secureSocketConfig;
+        http:Client httpEp = check new (serviceUrl, { auth: clientConfig.authConfig, secureSocket: secureSocketConfig });
+        self.clientEp = httpEp;
+    }
+    #
+    # + xEbayCMarketplaceId - Use this header to specify the eBay marketplace identifier. Supported values for this header can be found in the MarketplaceIdEnum type definition. Note that Version 1.4.0 of the Compliance API is only supported on the US, UK, Australia, Canada {English), and Germany sites.
+    # + complianceType - A user passes in one or more compliance type values through this query parameter. See ComplianceTypeEnum for more information on the supported compliance types that can be passed in here. If more than one compliance type value is used, delimit these values with a comma. If no compliance type values are passed in, the listing count for all compliance types will be returned. Note: Only a canned response, with counts for all listing compliance types, is returned in the Sandbox environment. Due to this limitation, the compliance_type query parameter (if used) will not have an effect on the response.
+    # + return - Success
+    remote isolated function getListingViolationsSummary(string? xEbayCMarketplaceId = (), string? complianceType = ()) returns ComplianceSummary|error {
+        string  path = string `/listing_violation_summary`;
+        map<anydata> queryParam = {"compliance_type": complianceType};
+        path = path + check getPathForQueryParam(queryParam);
+        map<any> headerValues = {"X-EBAY-C-MARKETPLACE-ID": xEbayCMarketplaceId};
+        map<string|string[]> accHeaders = getMapForHeaders(headerValues);
+        ComplianceSummary response = check self.clientEp-> get(path, accHeaders, targetType = ComplianceSummary);
+        return response;
+    }
+    #
+    # + xEbayCMarketplaceId - This header is required and is used to specify the eBay marketplace identifier. Supported values for this header can be found in the MarketplaceIdEnum type definition. Note that Version 1.4.0 of the Compliance API is only supported on the US, UK, Australia, Canada {English), and Germany sites.
+    # + complianceType - A seller uses this query parameter to retrieve listing violations of a specific compliance type. Only one compliance type value should be passed in here. See ComplianceTypeEnum for more information on the compliance types that can be passed in here. If the listing_id query parameter is used, the compliance_type query parameter {if passed in) will be ignored. This is because all of a listing's policy violations {each compliance type) will be returned if a listing_id is provided. Either the listing_id or a compliance_type query parameter must be used, and if the seller only wants to view listing violations of a specific compliance type, both of these parameters can be used. Note: The listing_id query parameter is not yet available for use, so the seller does not have the ability to retrieve listing violations for one or more specific listings. Until the listing_id query parameter becomes available, the compliance_type query parameter is required with each getListingViolations call.
+    # + offset - The integer value input into this field controls the first listing violation in the result set that will be displayed at the top of the response. The offset and limit query parameters are used to control the pagination of the output. For example, if offset is set to 10 and limit is set to 10, the call retrieves listing violations 11 thru 20 from the resulting set of violations. Note: This feature employs a zero-based index, where the first item in the list has an offset of 0. If the listing_id parameter is included in the request, this parameter will be ignored. Default: 0 {zero)
+    # + listingId - Note: This query parameter is not yet supported for the Compliance API. Please note that until this query parameter becomes available, the compliance_type query parameter is required with each getListingViolations call. This query parameter is used if the user wants to view all listing violations for one or more eBay listings. The string value passed into this field is the unique identifier of the listing, sometimes referred to as the Item ID. Either the listing_id or a compliance_type query parameter must be used, and if the seller only wants to view listing violations of a specific compliance type, both of these parameters can be used. Up to 50 listing IDs can be specified with this query parameter, and each unique listing ID is separated with a comma.
+    # + 'limit - This query parameter is used if the user wants to set a limit on the number of listing violations that are returned on one page of the result set. This parameter is used in conjunction with the offset parameter to control the pagination of the output. For example, if offset is set to 10 and limit is set to 10, the call retrieves listing violations 11 thru 20 from the collection of listing violations that match the value set in the compliance_type parameter. Note: This feature employs a zero-based index, where the first item in the list has an offset of 0. If the listing_id parameter is included in the request, this parameter will be ignored. Default: 100 Maximum: 200
+    # + filter - This filter allows a user to retrieve only listings that are currently out of compliance, or only listings that are at risk of becoming out of compliance. Although other filters may be added in the future, complianceState is the only supported filter type at this time. The two compliance 'states' are OUT_OF_COMPLIANCE and AT_RISK. Below is an example of how to set up this compliance state filter. Notice that the filter type and filter value are separated with a colon (:) character, and the filter value is wrapped with curly brackets. filter=complianceState:{OUT_OF_COMPLIANCE}
+    # + return - Success
+    remote isolated function getListingViolations(string xEbayCMarketplaceId, string? complianceType = (), string? offset = (), string? listingId = (), string? 'limit = (), string? filter = ()) returns PagedComplianceViolationCollection|error {
+        string  path = string `/listing_violation`;
+        map<anydata> queryParam = {"compliance_type": complianceType, "offset": offset, "listing_id": listingId, "limit": 'limit, "filter": filter};
+        path = path + check getPathForQueryParam(queryParam);
+        map<any> headerValues = {"X-EBAY-C-MARKETPLACE-ID": xEbayCMarketplaceId};
+        map<string|string[]> accHeaders = getMapForHeaders(headerValues);
+        PagedComplianceViolationCollection response = check self.clientEp-> get(path, accHeaders, targetType = PagedComplianceViolationCollection);
+        return response;
+    }
+    #
+    # + payload - This type is the base request type of the SuppressViolation method.
+    # + return - Success
+    remote isolated function suppressViolation(SuppressViolationRequest payload) returns http:Response|error {
+        string  path = string `/suppress_listing_violation`;
+        http:Request request = new;
+        json jsonBody = check payload.cloneWithType(json);
+        request.setPayload(jsonBody);
+        http:Response response = check self.clientEp->post(path, request, targetType=http:Response);
+        return response;
+    }
+}
+
+# Generate query path with query parameter.
+#
+# + queryParam - Query parameter map
+# + return - Returns generated Path or error at failure of client initialization
+isolated function  getPathForQueryParam(map<anydata> queryParam)  returns  string|error {
+    string[] param = [];
+    param[param.length()] = "?";
+    foreach  var [key, value] in  queryParam.entries() {
+        if  value  is  () {
+            _ = queryParam.remove(key);
+        } else {
+            if  string:startsWith( key, "'") {
+                 param[param.length()] = string:substring(key, 1, key.length());
+            } else {
+                param[param.length()] = key;
+            }
+            param[param.length()] = "=";
+            if  value  is  string {
+                string updateV =  check url:encode(value, "UTF-8");
+                param[param.length()] = updateV;
+            } else {
+                param[param.length()] = value.toString();
+            }
+            param[param.length()] = "&";
+        }
+    }
+    _ = param.remove(param.length()-1);
+    if  param.length() ==  1 {
+        _ = param.remove(0);
+    }
+    string restOfPath = string:'join("", ...param);
+    return restOfPath;
+}
+
+# Generate header map for given header values.
+#
+# + headerParam - Headers  map
+# + return - Returns generated map or error at failure of client initialization
+isolated function  getMapForHeaders(map<any> headerParam)  returns  map<string|string[]> {
+    map<string|string[]> headerMap = {};
+    foreach  var [key, value] in  headerParam.entries() {
+        if  value  is  string ||  value  is  string[] {
+            headerMap[key] = value;
+        }
+    }
+    return headerMap;
+}

--- a/openapi/ebay.compliance/openapi.yml
+++ b/openapi/ebay.compliance/openapi.yml
@@ -1,0 +1,464 @@
+openapi: 3.0.0
+info:
+  title: Compliance API
+  description: >
+    This is a generated connector for [eBay Compliance API v1.4.1](https://developer.ebay.com) OpenAPI specification.
+
+    'Service for providing information to sellers about their listings being non-compliant, or at risk for becoming non-compliant, against eBay listing policies.'
+  x-init-description: >
+    The connector initialization requires setting the API credentials.
+
+    Create [eBay developer account](https://developer.ebay.com/join/) and obtain tokens by following [this guide](https://developer.ebay.com/api-docs/static/oauth-tokens.html).
+  contact:
+    name: 'eBay Inc,'
+  license:
+    name: eBay API License Agreement
+    url: 'https://go.developer.ebay.com/api-license-agreement'
+  version: 1.4.1
+servers:
+  - url: 'https://api.ebay.com{basePath}'
+    description: Production
+    variables:
+      basePath:
+        default: /sell/compliance/v1
+paths:
+  /listing_violation_summary:
+    get:
+      tags:
+        - listing_violation_summary
+      description: 'This call returns listing violation counts for a seller. A user can pass in one or more compliance types through the compliance_type query parameter. See ComplianceTypeEnum for more information on the supported listing compliance types. Listing violations are returned for multiple marketplaces if the seller sells on multiple eBay marketplaces. Note: Only a canned response, with counts for all listing compliance types, is returned in the Sandbox environment. Due to this limitation, the compliance_type query parameter (if used) will not have an effect on the response.'
+      operationId: getListingViolationsSummary
+      parameters:
+        - name: X-EBAY-C-MARKETPLACE-ID
+          in: header
+          description: 'Use this header to specify the eBay marketplace identifier. Supported values for this header can be found in the MarketplaceIdEnum type definition. Note that Version 1.4.0 of the Compliance API is only supported on the US, UK, Australia, Canada {English), and Germany sites.'
+          required: false
+          schema:
+            type: string
+        - name: compliance_type
+          in: query
+          description: 'A user passes in one or more compliance type values through this query parameter. See ComplianceTypeEnum for more information on the supported compliance types that can be passed in here. If more than one compliance type value is used, delimit these values with a comma. If no compliance type values are passed in, the listing count for all compliance types will be returned. Note: Only a canned response, with counts for all listing compliance types, is returned in the Sandbox environment. Due to this limitation, the compliance_type query parameter (if used) will not have an effect on the response.'
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ComplianceSummary'
+        '204':
+          description: No Content
+        '400':
+          description: Bad Request
+          x-response-codes:
+            errors:
+              '850101':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Marketplace ID is invalid
+              '850110':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Compliance type is invalid
+              '850111':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Compliance type is missing
+              '850114':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Mandatory headers are missing
+        '500':
+          description: Internal Server Error
+          x-response-codes:
+            errors:
+              '850001':
+                domain: API_COMPLIANCE
+                category: APPLICATION
+                description: 'Any System error. {additionalInfo}'
+      security:
+        - api_auth:
+            - 'https://api.ebay.com/oauth/api_scope/sell.inventory'
+  /listing_violation:
+    get:
+      tags:
+        - listing_violation
+      description: 'This call returns specific listing violations for the supported listing compliance types. Only one compliance type can be passed in per call, and the response will include all the listing violations for this compliance type, and listing violations are grouped together by eBay listing ID. See ComplianceTypeEnum for more information on the supported listing compliance types. This method also has pagination control. Note: A maximum of 2000 listing violations will be returned in a result set. If the seller has more than 2000 listing violations, some/all of those listing violations must be corrected before additional listing violations will be retrieved. The user should pay attention to the total value in the response. If this value is ''2000'', it is possible that the seller has more than 2000 listing violations, but this field maxes out at 2000. Note: In a future release of this API, the seller will be able to pass in a specific eBay listing ID as a query parameter to see if this specific listing has any violations. Note: Only mocked non-compliant listing data will be returned for this call in the Sandbox environment, and not specific to the seller. However, the user can still use this mock data to experiment with the compliance type filters and pagination control.'
+      operationId: getListingViolations
+      parameters:
+        - name: X-EBAY-C-MARKETPLACE-ID
+          in: header
+          description: 'This header is required and is used to specify the eBay marketplace identifier. Supported values for this header can be found in the MarketplaceIdEnum type definition. Note that Version 1.4.0 of the Compliance API is only supported on the US, UK, Australia, Canada {English), and Germany sites.'
+          required: true
+          schema:
+            type: string
+        - name: compliance_type
+          in: query
+          description: 'A seller uses this query parameter to retrieve listing violations of a specific compliance type. Only one compliance type value should be passed in here. See ComplianceTypeEnum for more information on the compliance types that can be passed in here. If the listing_id query parameter is used, the compliance_type query parameter {if passed in) will be ignored. This is because all of a listing''s policy violations {each compliance type) will be returned if a listing_id is provided. Either the listing_id or a compliance_type query parameter must be used, and if the seller only wants to view listing violations of a specific compliance type, both of these parameters can be used. Note: The listing_id query parameter is not yet available for use, so the seller does not have the ability to retrieve listing violations for one or more specific listings. Until the listing_id query parameter becomes available, the compliance_type query parameter is required with each getListingViolations call.'
+          required: false
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description: 'The integer value input into this field controls the first listing violation in the result set that will be displayed at the top of the response. The offset and limit query parameters are used to control the pagination of the output. For example, if offset is set to 10 and limit is set to 10, the call retrieves listing violations 11 thru 20 from the resulting set of violations. Note: This feature employs a zero-based index, where the first item in the list has an offset of 0. If the listing_id parameter is included in the request, this parameter will be ignored. Default: 0 {zero)'
+          required: false
+          schema:
+            type: string
+        - name: listing_id
+          in: query
+          description: 'Note: This query parameter is not yet supported for the Compliance API. Please note that until this query parameter becomes available, the compliance_type query parameter is required with each getListingViolations call. This query parameter is used if the user wants to view all listing violations for one or more eBay listings. The string value passed into this field is the unique identifier of the listing, sometimes referred to as the Item ID. Either the listing_id or a compliance_type query parameter must be used, and if the seller only wants to view listing violations of a specific compliance type, both of these parameters can be used. Up to 50 listing IDs can be specified with this query parameter, and each unique listing ID is separated with a comma.'
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: 'This query parameter is used if the user wants to set a limit on the number of listing violations that are returned on one page of the result set. This parameter is used in conjunction with the offset parameter to control the pagination of the output. For example, if offset is set to 10 and limit is set to 10, the call retrieves listing violations 11 thru 20 from the collection of listing violations that match the value set in the compliance_type parameter. Note: This feature employs a zero-based index, where the first item in the list has an offset of 0. If the listing_id parameter is included in the request, this parameter will be ignored. Default: 100 Maximum: 200'
+          required: false
+          schema:
+            type: string
+        - name: filter
+          in: query
+          description: 'This filter allows a user to retrieve only listings that are currently out of compliance, or only listings that are at risk of becoming out of compliance. Although other filters may be added in the future, complianceState is the only supported filter type at this time. The two compliance ''states'' are OUT_OF_COMPLIANCE and AT_RISK. Below is an example of how to set up this compliance state filter. Notice that the filter type and filter value are separated with a colon (:) character, and the filter value is wrapped with curly brackets. filter=complianceState:{OUT_OF_COMPLIANCE}'
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/PagedComplianceViolationCollection'
+        '204':
+          description: No Content
+        '400':
+          description: Bad Request
+          x-response-codes:
+            errors:
+              '850101':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Marketplace ID is invalid
+              '850102':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Marketplace ID is missing
+              '850109':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Single compliance type is supported per API call
+              '850110':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Compliance type is invalid
+              '850111':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Compliance type is missing
+              '850112':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Invalid listing_id specified
+              '850113':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: listing_id not specified
+              '850114':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Mandatory headers are missing
+        '500':
+          description: Internal Server Error
+          x-response-codes:
+            errors:
+              '850001':
+                domain: API_COMPLIANCE
+                category: APPLICATION
+                description: 'Any System error. {additionalInfo}'
+      security:
+        - api_auth:
+            - 'https://api.ebay.com/oauth/api_scope/sell.inventory'
+  /suppress_listing_violation:
+    post:
+      tags:
+        - listing_violation
+      description: 'This call suppresses a listing violation for a specific listing. Only listing violations in the AT_RISK state (returned in the violations.complianceState field of the getListingViolations call) can be suppressed. Note: At this time, the suppressViolation call only supports the suppressing of ASPECTS_ADOPTION listing violations in the AT_RISK state. In the future, it is possible that this method can be used to suppress other listing violation types. A successful call returns a http status code of 204 Success. There is no response payload. If the call is not successful, an error code will be returned stating the issue.'
+      operationId: suppressViolation
+      requestBody:
+        description: This type is the base request type of the SuppressViolation method.
+        content:
+          application/json:
+            schema:
+              description: This type is the base request type of the SuppressViolation method.
+              $ref: '#/components/schemas/SuppressViolationRequest'
+        required: true
+      responses:
+        '204':
+          description: Success
+        '400':
+          description: Bad Request
+          x-response-codes:
+            errors:
+              '850110':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Compliance type is invalid
+              '850111':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Compliance type is missing
+              '850112':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Invalid listing_id specified
+              '850113':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: listing_id not specified
+              '850120':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Listing is already compliant. You can not suppress compliant listing
+              '850121':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Listing has required aspects not filled. You can not suppress the violation when required aspects are missing
+              '850122':
+                domain: API_COMPLIANCE
+                category: REQUEST
+                description: Violation is already suppressed on this listing
+        '409':
+          description: Business error
+        '500':
+          description: Internal Server Error
+          x-response-codes:
+            errors:
+              '850001':
+                domain: API_COMPLIANCE
+                category: APPLICATION
+                description: Any System error
+      security:
+        - api_auth:
+            - 'https://api.ebay.com/oauth/api_scope/sell.inventory'
+components:
+  schemas:
+    AspectRecommendations:
+      type: object
+      properties:
+        localizedAspectName:
+          type: string
+          description: 'The name of the item aspect for which eBay has a recommendation. In many cases, the same item aspect(s) that are returned under the violationData array for ASPECTS_ADOPTION listing violations are also returned here Note: This name is always localized for the specified marketplace.'
+        suggestedValues:
+          type: array
+          description: One or more valid values for the corresponding item aspect (in localizedAspectName) are returned here. These suggested values for the item aspect depend on the listing category and on the information specified in the listing. Sellers should confirm accuracy of the values before applying them to the listing. Please use getItemAspectsForCategory in the Taxonomy API or GetCategorySpecifics in the Trading API to get a comprehensive list of required and recommended aspects for a given category and a list of supported aspect values for each.
+          items:
+            type: string
+      description: 'This type is used by the aspectsRecommendation container, which is returned if eBay has found a listing with missing or invalid item aspects (ASPECTS_ADOPTION compliance type).'
+    ComplianceDetail:
+      type: object
+      properties:
+        reasonCode:
+          type: string
+          description: 'This value states the nature of the listing violation. A reasonCode value is returned for each listing violation, and each compliance type can have several reason codes and related messages. The reasonCode values vary by compliance type. The reason codes for each compliance type are summarized below. Aspects adoption The reason codes for ASPECTS_ADOPTION compliance indicate that for the given violation, aspects listed in the violationData container are either missing from the listing or they have invalid values. The reason codes specify whether the violation is for required aspects, recommended (preferred) aspects, or soon to be required aspects. MISSING_OR_INVALID_REQUIRED_ASPECTS MISSING_OR_INVALID_PREFERRED_ASPECTS MISSING_OR_INVALID_SOON_TO_BE_REQUIRED_ASPECTS HTTPS The reason codes for HTTPS compliance identify where in the listing the violation occurs. For HTTPS policy violations, the seller will just need to remove the HTTP link (or update to HTTPS) from the listing details or product details: NON_SECURE_HTTP_LINK_IN_LISTING NON_SECURE_HTTP_LINK_IN_PRODUCT Non-eBay links The reason codes for OUTSIDE_EBAY_BUYING_AND_SELLING compliance identify the specific type of data (e.g., telephone number) that violated the policy. For each of these violations, the seller will just need to revise the listing, removing this information: UNAPPROVED_DOMAIN_WEBLINK_IN_LISTING PHONE_NUMBER_IN_LISTING EMAIL_ADDRESS_IN_LISTING Product adoption Product Adoption is not enforced at this time. Product adoption conformance Product Adoption is not enforced at this time. Returns policy The only RETURNS_POLICY reason code is UNSUPPORTED_RETURNS_PERIOD. The seller will have to revise their listing (or return business policy) with a supported return period for the site and category. The GetCategoryFeatures call of the Trading API can be used to verify the supported return periods for a particular category. For most eBay categories, the minimum return period that can be stated in a Returns Policy is 14 days for domestic and international sales, but some categories require a minimum 30-day return period.'
+        message:
+          type: string
+          description: This field provides a textual summary of the listing violation. A message field is returned for each listing violation. This message will vary widely based on the compliance type and corresponding reason code.
+        variation:
+          description: This container defines the variation within a multiple-variation listing that has the listing violation. This container is only returned if an individual variation within a multiple-variation listing has the listing violation.
+          $ref: '#/components/schemas/VariationDetails'
+        violationData:
+          type: array
+          description: 'This container provides more information about the listing violation, if applicable. The type of information that appears here will vary based on the compliance type and type of violation. For example, for ASPECTS_ADOPTION violations, this container lists the missing aspect(s) or aspect(s) with invalid values.'
+          items:
+            $ref: '#/components/schemas/NameValueList'
+        correctiveRecommendations:
+          description: 'This container is returned for ASPECTS_ADOPTION violations if eBay has found one or more item aspect name-value pairs that may be appropriate for the seller''s product. In many cases, the missing or incorrect item aspect(s) shown under the corresponding violationData array, will also show up under the aspectRecommendations array with suggested value(s). Note: eBay catalog product adoption is not enforced for any eBay category at this time, so a recommended eBay product ID (aka ePID) will not be returned under the productRecommendation container at this time.'
+          $ref: '#/components/schemas/CorrectiveRecommendations'
+        complianceState:
+          type: string
+          description: 'The enumeration value returned in this field indicates if the listing violation is considered to be OUT_OF_COMPLIANCE with an eBay listing policy, or the listing is considered to be AT_RISK of becoming non-compliant against an eBay listing policy. Generally, OUT_OF_COMPLIANCE policy violations can prevent the seller from revising a listing until the underlying violation(s) can be remedied. When the compliance state is AT_RISK, the seller is not blocked from revising the listing, but the seller should correct the violation to prevent the listing from being blocked for revisions in the future. Note: This field is returned for most violations, but not all. In the case that this field is not returned, it can be assumed that the state of the listing violation is OUT_OF_COMPLIANCE. For implementation help, refer to <a href=''https://developer.ebay.com/api-docs/sell/compliance/types/com:ComplianceStateEnum''>eBay API documentation</a>'
+      description: This type is used by each listing violation that is returned under the violations container.
+    ComplianceSummary:
+      type: object
+      properties:
+        violationSummaries:
+          type: array
+          description: 'This container is an array of one or more policy violation counts. A policy violation count is returned for each unique eBay marketplace and compliance type violation. As long as there is at least one non-compliant listing for the specified compliance type(s), this container will be returned. If no non-compliant listings are found for the specified compliance type(s), an HTTP status code of 204 No Content is returned, and there is no response body.'
+          items:
+            $ref: '#/components/schemas/ComplianceSummaryInfo'
+      description: This type is the base type for the getListingViolationsSummary response. The violationSummaries container contains an array of policy violation counts for each unique eBay marketplace and compliance type violation.
+    ComplianceSummaryInfo:
+      type: object
+      properties:
+        complianceType:
+          type: string
+          description: 'This enumeration value indicates the type of compliance. See ComplianceTypeEnum for more information on each compliance type. For implementation help, refer to <a href=''https://developer.ebay.com/api-docs/sell/compliance/types/com:ComplianceTypeEnum''>eBay API documentation</a>'
+        marketplaceId:
+          type: string
+          description: 'This enumeration value indicates the eBay marketplace where the listing violations exist. For implementation help, refer to <a href=''https://developer.ebay.com/api-docs/sell/compliance/types/bas:MarketplaceIdEnum''>eBay API documentation</a>'
+        listingCount:
+          type: integer
+          description: 'This integer value indicates the number of eBay listings that are currently violating the compliance type indicated in the complianceType field, for the eBay marketplace indicated in the marketplaceId field.'
+          format: int32
+      description: This type is used by each unique eBay marketplace and compliance type combination that is returned in the getListingViolationsSummary response to indicate the total number of listing violations in regards to that eBay marketplace and compliance type.
+    ComplianceViolation:
+      type: object
+      properties:
+        complianceType:
+          type: string
+          description: 'This enumeration value indicates the compliance type of listing violation. See ComplianceTypeEnum for more information on each compliance type. This will always be returned for each listing violation that is found. For implementation help, refer to <a href=''https://developer.ebay.com/api-docs/sell/compliance/types/com:ComplianceTypeEnum''>eBay API documentation</a>'
+        listingId:
+          type: string
+          description: 'The unique identifier of the eBay listing that currently has the corresponding listing violation{s). This field will always be returned for each listing that has one or more violations.'
+        sku:
+          type: string
+          description: 'The seller-defined SKU value of the product in the listing with the violation{s). This field is only returned if defined in the listing. SKU values are optional in listings except when creating listings using the Inventory API model.'
+        offerId:
+          type: string
+          description: 'Note: This field is for future use, and will not be returned, even for listings created through the Inventory API. The unique identifier of the offer. This field is only applicable and returned for listings that were created through the Inventory API. To convert an Inventory Item object into an eBay listing, an Offer object must be created and published.'
+        violations:
+          type: array
+          description: 'This container consists of an array of one or more listing violations applicable to the eBay listing specified in the listingId field. This array is returned for each eBay listing that has one or more violations. For each returned violation, the fields that are returned and the details that are given will depend on the listing violation.'
+          items:
+            $ref: '#/components/schemas/ComplianceDetail'
+      description: This type is used by each listing violation that is returned under the listingViolations container.
+    CorrectiveRecommendations:
+      type: object
+      properties:
+        productRecommendation:
+          description: 'This container is only applicable (and possibly returned) for the PRODUCT_ADOPTION and PRODUCT_ADOPTION_CONFORMANCE compliance types, and since eBay catalog product adoption is not enforced for any eBay category at this time, the productRecommendation container will not be returned at this time.'
+          $ref: '#/components/schemas/ProductRecommendation'
+        aspectRecommendations:
+          type: array
+          description: 'This container is returned for ASPECTS_ADOPTION violations if eBay has found one or more item aspect name-value pairs that may be appropriate for the seller''s product. In many cases, the missing or invalid item aspect(s) shown under the corresponding violationData array, will also show up under this array with suggested value(s).'
+          items:
+            $ref: '#/components/schemas/AspectRecommendations'
+      description: 'This type is used by the correctiveRecommendations container, which is returned if eBay has suggestions for how to correct the given violation.'
+    Error:
+      type: object
+      properties:
+        category:
+          type: string
+          description: Identifies the type of erro.
+        domain:
+          type: string
+          description: Name for the primary system where the error occurred. This is relevant for application errors.
+        errorId:
+          type: integer
+          description: A unique number to identify the error.
+          format: int32
+        inputRefIds:
+          type: array
+          description: An array of request elements most closely associated to the error.
+          items:
+            type: string
+        longMessage:
+          type: string
+          description: A more detailed explanation of the error.
+        message:
+          type: string
+          description: 'Information on how to correct the problem, in the end user''s terms and language where applicable.'
+        outputRefIds:
+          type: array
+          description: An array of request elements most closely associated to the error.
+          items:
+            type: string
+        parameters:
+          type: array
+          description: An array of name/value pairs that describe details the error condition. These are useful when multiple errors are returned.
+          items:
+            $ref: '#/components/schemas/ErrorParameter'
+        subdomain:
+          type: string
+          description: 'Further helps indicate which subsystem the error is coming from. System subcategories include: Initialization, Serialization, Security, Monitoring, Rate Limiting, etc.'
+      description: This type defines the fields that can be returned in an error.
+    ErrorParameter:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The object of the error.
+        value:
+          type: string
+          description: The value of the object.
+    NameValueList:
+      type: object
+      properties:
+        name:
+          type: string
+          description: 'This is the name of the variation aspect, or the name of the category of information that is returned through the name-value pair. The type of information that appears here will vary based on the compliance type and type of violation.'
+        value:
+          type: string
+          description: 'This is the value of the variation aspect (in name field), or the value of the category of information that is returned through the name-value pair. The type of information that appears here will vary based on the compliance type and type of violation.'
+      description: 'This type is used to provide a name-value pair, including the identifying aspects of a product variation through the variationAspects container.'
+    PagedComplianceViolationCollection:
+      type: object
+      properties:
+        offset:
+          type: integer
+          description: 'This integer value shows the offset of the current page of results. The offset value controls the first listing violation in the result set that will be displayed at the top of the response. The offset and limit query parameters are used to control the pagination of the output. For example, if offset is set to 10 and limit is set to 10, the call retrieves listing violations 11 thru 20 from the resulting collection of violations. Note: This feature employs a zero-based index, where the first item in the list has an offset of 0. Default: 0 {zero)'
+          format: int32
+        href:
+          type: string
+          description: The URI of the getListingViolations call request that produced the current page of the result set.
+        total:
+          type: integer
+          description: 'The total number of listing violations in the result set. If this value is higher than the limit value, there are multiple pages in the result set to view.'
+          format: int32
+        next:
+          type: string
+          description: 'The getListingViolations call URI to use to view the next page of the result set. For example, the following URI returns listing violations 21 thru 30 from the collection of policy violations: path/listing_violation?limit=10&amp;offset=20 This field is only returned if an additional page of listing violations exists.'
+        prev:
+          type: string
+          description: 'The getListingViolations call URI to use to view the previous page of the result set. For example, the following URI returns listing violations 1 thru 10 from the collection of policy violations: path/listing_violation?limit=10&amp;offset=0 This field is only returned if an previous page of listing violations exists.'
+        limit:
+          type: integer
+          description: 'The maximum number of listing violations returned per page of the result set. The limit and offset query parameters are used to control the pagination of the output. Note: If this is the last or only page in the result set, it may contain fewer listing violations than the limit value. To determine the number of pages in the result set, divide this value into the value of total and round up to the next integer. Default: 50 Max: 200'
+          format: int32
+        listingViolations:
+          type: array
+          description: 'An array of listing violations that match the criteria in the call request, including pagination control {if set). As long as there is at least one listing violation that matches the input criteria, this container will be returned. If no listing violations are found for the seller, an HTTP status code of 204 No Content is returned, and there is no response body.'
+          items:
+            $ref: '#/components/schemas/ComplianceViolation'
+      description: This type is the base response type of the getListingViolations method.
+    ProductRecommendation:
+      type: object
+      properties:
+        epid:
+          type: string
+          description: 'This field will return the eBay Product ID {ePID) of an eBay Catalog product that eBay recommends that the seller use to make their listing compliant. Note: Product Adoption is not enforced at this time. Product Adoption violations are no longer returned.'
+      description: 'This type is used by the productRecommendation container, which is returned if eBay has found an eBay catalog product that may be a match for the product (or product variation) that has a listing violation. Note: eBay catalog product adoption is not enforced at this time, so product adoption violations are no longer returned. Due to this fact, this type and productRecommendation container are not currently applicable.'
+    SuppressViolationRequest:
+      type: object
+      properties:
+        complianceType:
+          type: string
+          description: 'The compliance type of the listing violation to suppress is specified in this field. The compliance type for each listing violation is found in the complianceType field under the listingViolations array in a getListingViolations response. Note: At this time, the suppressViolation method is only used to suppress aspect adoption listing violations in the ''at-risk'' state, so ASPECTS_ADOPTION is currently the only supported value for this field. For implementation help, refer to <a href=''https://developer.ebay.com/api-docs/sell/compliance/types/com:ComplianceTypeEnum''>eBay API documentation</a>'
+        listingId:
+          type: string
+          description: 'The unique identifier of the listing with the violation(s) is specified in this field. The unique identifier of the listing with the listing violation(s) is found in the listingId field under the listingViolations array in a getListingViolations response. Note: At this time, the suppressViolation method is only used to suppress aspect adoption listing violations in the ''at-risk'' state, so the listing specified in this field should be a listing with an ASPECTS_ADOPTION violation in the ''at-risk'' state.'
+      description: 'This is the base request type of the suppressViolation method, and is used to identify the listing violation that the seller wishes to suppress.'
+    VariationDetails:
+      type: object
+      properties:
+        sku:
+          type: string
+          description: 'The seller-defined SKU value of the variation within the multiple-variation listing with the violation{s). This field is only returned if a seller-defined SKU value is defined for the variation. SKU values are optional in listing except when creating listings using the Inventory API.'
+        variationAspects:
+          type: array
+          description: 'An array of one or more variation aspects that define a variation within a multiple-variation listing. The aspect{s) returned here define the individual variation, because these aspects will differ for each variation. Common varying aspects include color and size.'
+          items:
+            $ref: '#/components/schemas/NameValueList'
+      description: This type is used to identify the product variation that has the listing violation.
+  securitySchemes:
+    api_auth:
+      type: oauth2
+      description: The security definitions for this API. Please check individual operations for applicable scopes.
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://auth.ebay.com/oauth2/authorize'
+          tokenUrl: 'https://api.ebay.com/identity/v1/oauth2/token'
+          scopes:
+            'https://api.ebay.com/oauth/api_scope/sell.inventory': View and manage your inventory and offers

--- a/openapi/ebay.compliance/types.bal
+++ b/openapi/ebay.compliance/types.bal
@@ -1,0 +1,154 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# This type is used by the productRecommendation container, which is returned if eBay has found an eBay catalog product that may be a match for the product (or product variation) that has a listing violation. Note: eBay catalog product adoption is not enforced at this time, so product adoption violations are no longer returned. Due to this fact, this type and productRecommendation container are not currently applicable.
+public type ProductRecommendation record {
+    # This field will return the eBay Product ID {ePID) of an eBay Catalog product that eBay recommends that the seller use to make their listing compliant. Note: Product Adoption is not enforced at this time. Product Adoption violations are no longer returned.
+    string epid?;
+};
+
+# This type is the base type for the getListingViolationsSummary response. The violationSummaries container contains an array of policy violation counts for each unique eBay marketplace and compliance type violation.
+public type ComplianceSummary record {
+    # This container is an array of one or more policy violation counts. A policy violation count is returned for each unique eBay marketplace and compliance type violation. As long as there is at least one non-compliant listing for the specified compliance type(s), this container will be returned. If no non-compliant listings are found for the specified compliance type(s), an HTTP status code of 204 No Content is returned, and there is no response body.
+    ComplianceSummaryInfo[] violationSummaries?;
+};
+
+# This type is used to provide a name-value pair, including the identifying aspects of a product variation through the variationAspects container.
+public type NameValueList record {
+    # This is the name of the variation aspect, or the name of the category of information that is returned through the name-value pair. The type of information that appears here will vary based on the compliance type and type of violation.
+    string name?;
+    # This is the value of the variation aspect (in name field), or the value of the category of information that is returned through the name-value pair. The type of information that appears here will vary based on the compliance type and type of violation.
+    string value?;
+};
+
+# This type is used by each listing violation that is returned under the violations container.
+public type ComplianceDetail record {
+    # This value states the nature of the listing violation. A reasonCode value is returned for each listing violation, and each compliance type can have several reason codes and related messages. The reasonCode values vary by compliance type. The reason codes for each compliance type are summarized below. Aspects adoption The reason codes for ASPECTS_ADOPTION compliance indicate that for the given violation, aspects listed in the violationData container are either missing from the listing or they have invalid values. The reason codes specify whether the violation is for required aspects, recommended (preferred) aspects, or soon to be required aspects. MISSING_OR_INVALID_REQUIRED_ASPECTS MISSING_OR_INVALID_PREFERRED_ASPECTS MISSING_OR_INVALID_SOON_TO_BE_REQUIRED_ASPECTS HTTPS The reason codes for HTTPS compliance identify where in the listing the violation occurs. For HTTPS policy violations, the seller will just need to remove the HTTP link (or update to HTTPS) from the listing details or product details: NON_SECURE_HTTP_LINK_IN_LISTING NON_SECURE_HTTP_LINK_IN_PRODUCT Non-eBay links The reason codes for OUTSIDE_EBAY_BUYING_AND_SELLING compliance identify the specific type of data (e.g., telephone number) that violated the policy. For each of these violations, the seller will just need to revise the listing, removing this information: UNAPPROVED_DOMAIN_WEBLINK_IN_LISTING PHONE_NUMBER_IN_LISTING EMAIL_ADDRESS_IN_LISTING Product adoption Product Adoption is not enforced at this time. Product adoption conformance Product Adoption is not enforced at this time. Returns policy The only RETURNS_POLICY reason code is UNSUPPORTED_RETURNS_PERIOD. The seller will have to revise their listing (or return business policy) with a supported return period for the site and category. The GetCategoryFeatures call of the Trading API can be used to verify the supported return periods for a particular category. For most eBay categories, the minimum return period that can be stated in a Returns Policy is 14 days for domestic and international sales, but some categories require a minimum 30-day return period.
+    string reasonCode?;
+    # This field provides a textual summary of the listing violation. A message field is returned for each listing violation. This message will vary widely based on the compliance type and corresponding reason code.
+    string message?;
+    # This type is used to identify the product variation that has the listing violation.
+    VariationDetails variation?;
+    # This container provides more information about the listing violation, if applicable. The type of information that appears here will vary based on the compliance type and type of violation. For example, for ASPECTS_ADOPTION violations, this container lists the missing aspect(s) or aspect(s) with invalid values.
+    NameValueList[] violationData?;
+    # This type is used by the correctiveRecommendations container, which is returned if eBay has suggestions for how to correct the given violation.
+    CorrectiveRecommendations correctiveRecommendations?;
+    # The enumeration value returned in this field indicates if the listing violation is considered to be OUT_OF_COMPLIANCE with an eBay listing policy, or the listing is considered to be AT_RISK of becoming non-compliant against an eBay listing policy. Generally, OUT_OF_COMPLIANCE policy violations can prevent the seller from revising a listing until the underlying violation(s) can be remedied. When the compliance state is AT_RISK, the seller is not blocked from revising the listing, but the seller should correct the violation to prevent the listing from being blocked for revisions in the future. Note: This field is returned for most violations, but not all. In the case that this field is not returned, it can be assumed that the state of the listing violation is OUT_OF_COMPLIANCE. For implementation help, refer to <a href='https://developer.ebay.com/api-docs/sell/compliance/types/com:ComplianceStateEnum'>eBay API documentation</a>
+    string complianceState?;
+};
+
+# This type defines the fields that can be returned in an error.
+public type Error record {
+    # Identifies the type of erro.
+    string category?;
+    # Name for the primary system where the error occurred. This is relevant for application errors.
+    string domain?;
+    # A unique number to identify the error.
+    int errorId?;
+    # An array of request elements most closely associated to the error.
+    string[] inputRefIds?;
+    # A more detailed explanation of the error.
+    string longMessage?;
+    # Information on how to correct the problem, in the end user's terms and language where applicable.
+    string message?;
+    # An array of request elements most closely associated to the error.
+    string[] outputRefIds?;
+    # An array of name/value pairs that describe details the error condition. These are useful when multiple errors are returned.
+    ErrorParameter[] parameters?;
+    # Further helps indicate which subsystem the error is coming from. System subcategories include: Initialization, Serialization, Security, Monitoring, Rate Limiting, etc.
+    string subdomain?;
+};
+
+public type ErrorParameter record {
+    # The object of the error.
+    string name?;
+    # The value of the object.
+    string value?;
+};
+
+# This type is the base response type of the getListingViolations method.
+public type PagedComplianceViolationCollection record {
+    # This integer value shows the offset of the current page of results. The offset value controls the first listing violation in the result set that will be displayed at the top of the response. The offset and limit query parameters are used to control the pagination of the output. For example, if offset is set to 10 and limit is set to 10, the call retrieves listing violations 11 thru 20 from the resulting collection of violations. Note: This feature employs a zero-based index, where the first item in the list has an offset of 0. Default: 0 {zero)
+    int offset?;
+    # The URI of the getListingViolations call request that produced the current page of the result set.
+    string href?;
+    # The total number of listing violations in the result set. If this value is higher than the limit value, there are multiple pages in the result set to view.
+    int total?;
+    # The getListingViolations call URI to use to view the next page of the result set. For example, the following URI returns listing violations 21 thru 30 from the collection of policy violations: path/listing_violation?limit=10&amp;offset=20 This field is only returned if an additional page of listing violations exists.
+    string next?;
+    # The getListingViolations call URI to use to view the previous page of the result set. For example, the following URI returns listing violations 1 thru 10 from the collection of policy violations: path/listing_violation?limit=10&amp;offset=0 This field is only returned if an previous page of listing violations exists.
+    string prev?;
+    # The maximum number of listing violations returned per page of the result set. The limit and offset query parameters are used to control the pagination of the output. Note: If this is the last or only page in the result set, it may contain fewer listing violations than the limit value. To determine the number of pages in the result set, divide this value into the value of total and round up to the next integer. Default: 50 Max: 200
+    int 'limit?;
+    # An array of listing violations that match the criteria in the call request, including pagination control {if set). As long as there is at least one listing violation that matches the input criteria, this container will be returned. If no listing violations are found for the seller, an HTTP status code of 204 No Content is returned, and there is no response body.
+    ComplianceViolation[] listingViolations?;
+};
+
+# This is the base request type of the suppressViolation method, and is used to identify the listing violation that the seller wishes to suppress.
+public type SuppressViolationRequest record {
+    # The compliance type of the listing violation to suppress is specified in this field. The compliance type for each listing violation is found in the complianceType field under the listingViolations array in a getListingViolations response. Note: At this time, the suppressViolation method is only used to suppress aspect adoption listing violations in the 'at-risk' state, so ASPECTS_ADOPTION is currently the only supported value for this field. For implementation help, refer to <a href='https://developer.ebay.com/api-docs/sell/compliance/types/com:ComplianceTypeEnum'>eBay API documentation</a>
+    string complianceType?;
+    # The unique identifier of the listing with the violation(s) is specified in this field. The unique identifier of the listing with the listing violation(s) is found in the listingId field under the listingViolations array in a getListingViolations response. Note: At this time, the suppressViolation method is only used to suppress aspect adoption listing violations in the 'at-risk' state, so the listing specified in this field should be a listing with an ASPECTS_ADOPTION violation in the 'at-risk' state.
+    string listingId?;
+};
+
+# This type is used by the aspectsRecommendation container, which is returned if eBay has found a listing with missing or invalid item aspects (ASPECTS_ADOPTION compliance type).
+public type AspectRecommendations record {
+    # The name of the item aspect for which eBay has a recommendation. In many cases, the same item aspect(s) that are returned under the violationData array for ASPECTS_ADOPTION listing violations are also returned here Note: This name is always localized for the specified marketplace.
+    string localizedAspectName?;
+    # One or more valid values for the corresponding item aspect (in localizedAspectName) are returned here. These suggested values for the item aspect depend on the listing category and on the information specified in the listing. Sellers should confirm accuracy of the values before applying them to the listing. Please use getItemAspectsForCategory in the Taxonomy API or GetCategorySpecifics in the Trading API to get a comprehensive list of required and recommended aspects for a given category and a list of supported aspect values for each.
+    string[] suggestedValues?;
+};
+
+# This type is used by each unique eBay marketplace and compliance type combination that is returned in the getListingViolationsSummary response to indicate the total number of listing violations in regards to that eBay marketplace and compliance type.
+public type ComplianceSummaryInfo record {
+    # This enumeration value indicates the type of compliance. See ComplianceTypeEnum for more information on each compliance type. For implementation help, refer to <a href='https://developer.ebay.com/api-docs/sell/compliance/types/com:ComplianceTypeEnum'>eBay API documentation</a>
+    string complianceType?;
+    # This enumeration value indicates the eBay marketplace where the listing violations exist. For implementation help, refer to <a href='https://developer.ebay.com/api-docs/sell/compliance/types/bas:MarketplaceIdEnum'>eBay API documentation</a>
+    string marketplaceId?;
+    # This integer value indicates the number of eBay listings that are currently violating the compliance type indicated in the complianceType field, for the eBay marketplace indicated in the marketplaceId field.
+    int listingCount?;
+};
+
+# This type is used by each listing violation that is returned under the listingViolations container.
+public type ComplianceViolation record {
+    # This enumeration value indicates the compliance type of listing violation. See ComplianceTypeEnum for more information on each compliance type. This will always be returned for each listing violation that is found. For implementation help, refer to <a href='https://developer.ebay.com/api-docs/sell/compliance/types/com:ComplianceTypeEnum'>eBay API documentation</a>
+    string complianceType?;
+    # The unique identifier of the eBay listing that currently has the corresponding listing violation{s). This field will always be returned for each listing that has one or more violations.
+    string listingId?;
+    # The seller-defined SKU value of the product in the listing with the violation{s). This field is only returned if defined in the listing. SKU values are optional in listings except when creating listings using the Inventory API model.
+    string sku?;
+    # Note: This field is for future use, and will not be returned, even for listings created through the Inventory API. The unique identifier of the offer. This field is only applicable and returned for listings that were created through the Inventory API. To convert an Inventory Item object into an eBay listing, an Offer object must be created and published.
+    string offerId?;
+    # This container consists of an array of one or more listing violations applicable to the eBay listing specified in the listingId field. This array is returned for each eBay listing that has one or more violations. For each returned violation, the fields that are returned and the details that are given will depend on the listing violation.
+    ComplianceDetail[] violations?;
+};
+
+# This type is used to identify the product variation that has the listing violation.
+public type VariationDetails record {
+    # The seller-defined SKU value of the variation within the multiple-variation listing with the violation{s). This field is only returned if a seller-defined SKU value is defined for the variation. SKU values are optional in listing except when creating listings using the Inventory API.
+    string sku?;
+    # An array of one or more variation aspects that define a variation within a multiple-variation listing. The aspect{s) returned here define the individual variation, because these aspects will differ for each variation. Common varying aspects include color and size.
+    NameValueList[] variationAspects?;
+};
+
+# This type is used by the correctiveRecommendations container, which is returned if eBay has suggestions for how to correct the given violation.
+public type CorrectiveRecommendations record {
+    # This type is used by the productRecommendation container, which is returned if eBay has found an eBay catalog product that may be a match for the product (or product variation) that has a listing violation. Note: eBay catalog product adoption is not enforced at this time, so product adoption violations are no longer returned. Due to this fact, this type and productRecommendation container are not currently applicable.
+    ProductRecommendation productRecommendation?;
+    # This container is returned for ASPECTS_ADOPTION violations if eBay has found one or more item aspect name-value pairs that may be appropriate for the seller's product. In many cases, the missing or invalid item aspect(s) shown under the corresponding violationData array, will also show up under this array with suggested value(s).
+    AspectRecommendations[] aspectRecommendations?;
+};


### PR DESCRIPTION
## Purpose
resolves  https://github.com/wso2-enterprise/choreo/issues/7140

## Goals
adding eBay connector which belongs under the e-commerce category.

## Documentation
https://developer.ebay.com/api-docs/sell/compliance/overview.html

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
