### PR TITLE
[SL Alpha 5] Update the Dependencies.toml file with SL Alpha 5 dependencies for Nytimes newswire connector

### DIFF
--- a/openapi/nytimes.newswire/Dependencies.toml
+++ b/openapi/nytimes.newswire/Dependencies.toml
@@ -1,11 +1,11 @@
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-beta.2"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "url"
-version = "1.1.0-beta.2"
+version = "1.1.0-alpha8"
 
 


### PR DESCRIPTION
## Purpose
> Dependencies.toml file was commited with SL Beta 2 dependencies for the `slalpha5 branch`. Update the Dependencies.toml file with SL Alpha 5 dependencies.

## Goals
> Update the Dependencies.toml file with SL Alpha 5 dependencies.

## Approach
> Update the Dependencies.toml file with SL Alpha 5 dependencies.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
JDK 11
Ballerina Beta 2
Ubuntu 20.04