### PR TITLE
Add missing comma in keywords of `siemens.platformcore.identitymanagement` connector

### DIFF
--- a/openapi/siemens.platformcore.identitymanagement/Ballerina.toml
+++ b/openapi/siemens.platformcore.identitymanagement/Ballerina.toml
@@ -4,7 +4,7 @@ name = "siemens.platformcore.identitymanagement"
 version = "1.0.0-SNAPSHOT"
 distribution = "slbeta3"
 license = ["Apache-2.0"]
-keywords = ["IT Operations/Security & Identity Tools" "Cost/Freemium"]
+keywords = ["IT Operations/Security & Identity Tools", "Cost/Freemium"]
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
 authors = ["Ballerina"]
 


### PR DESCRIPTION
# Description
- Add missing comma in keywords of `siemens.platformcore.identitymanagement` connector
- This comma was missed in https://github.com/ballerina-platform/ballerinax-openapi-connectors/pull/494 when updating keywords


### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 