### PR TITLE
Update Dependencies.toml with correct versions

### DIFF
--- a/openapi/ably/Dependencies.toml
+++ b/openapi/ably/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ably"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/adp.paystatements/Dependencies.toml
+++ b/openapi/adp.paystatements/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "adp.paystatements"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/adp.workerpayrollinstructions/Dependencies.toml
+++ b/openapi/adp.workerpayrollinstructions/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "adp.workerpayrollinstructions"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/apideck.accounting/Dependencies.toml
+++ b/openapi/apideck.accounting/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "apideck.accounting"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/apideck.lead/Dependencies.toml
+++ b/openapi/apideck.lead/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "apideck.lead"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/apideck.proxy/Dependencies.toml
+++ b/openapi/apideck.proxy/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "apideck.proxy"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/apple.appstore/Dependencies.toml
+++ b/openapi/apple.appstore/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "apple.appstore"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/asana/Dependencies.toml
+++ b/openapi/asana/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "asana"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/atspoke/Dependencies.toml
+++ b/openapi/atspoke/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "atspoke"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/automata/Dependencies.toml
+++ b/openapi/automata/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "automata"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/avaza/Dependencies.toml
+++ b/openapi/avaza/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "avaza"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/azure.anomalydetector/Dependencies.toml
+++ b/openapi/azure.anomalydetector/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "azure.anomalydetector"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/azure.datalake/Dependencies.toml
+++ b/openapi/azure.datalake/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "azure.datalake"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/azure.iotcentral/Dependencies.toml
+++ b/openapi/azure.iotcentral/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "azure.iotcentral"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/azure.iothub/Dependencies.toml
+++ b/openapi/azure.iothub/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "azure.iothub"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/azure.keyvault/Dependencies.toml
+++ b/openapi/azure.keyvault/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "azure.keyvault"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/azure.qnamaker/Dependencies.toml
+++ b/openapi/azure.qnamaker/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "azure.qnamaker"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/azure.textanalytics/Dependencies.toml
+++ b/openapi/azure.textanalytics/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "azure.textanalytics"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/azure.timeseries/Dependencies.toml
+++ b/openapi/azure.timeseries/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "azure.timeseries"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/bing.autosuggest/Dependencies.toml
+++ b/openapi/bing.autosuggest/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "bing.autosuggest"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/bintable/Dependencies.toml
+++ b/openapi/bintable/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "bintable"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/bisstats/Dependencies.toml
+++ b/openapi/bisstats/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "bisstats"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/bitbucket/Dependencies.toml
+++ b/openapi/bitbucket/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "bitbucket"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/bitly/Dependencies.toml
+++ b/openapi/bitly/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "bitly"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/bmc.truesightpresentationserver/Dependencies.toml
+++ b/openapi/bmc.truesightpresentationserver/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "bmc.truesightpresentationserver"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/botify/Dependencies.toml
+++ b/openapi/botify/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "botify"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/box/Dependencies.toml
+++ b/openapi/box/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "box"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/brex.onboarding/Dependencies.toml
+++ b/openapi/brex.onboarding/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "brex.onboarding"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/brex.team/Dependencies.toml
+++ b/openapi/brex.team/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "brex.team"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/browshot/Dependencies.toml
+++ b/openapi/browshot/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "browshot"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/bulksms/Dependencies.toml
+++ b/openapi/bulksms/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "bulksms"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/chaingateway/Dependencies.toml
+++ b/openapi/chaingateway/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "chaingateway"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/clever.data/Dependencies.toml
+++ b/openapi/clever.data/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "clever.data"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/cloudmersive.barcode/Dependencies.toml
+++ b/openapi/cloudmersive.barcode/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cloudmersive.barcode"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/cloudmersive.currency/Dependencies.toml
+++ b/openapi/cloudmersive.currency/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cloudmersive.currency"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/cloudmersive.security/Dependencies.toml
+++ b/openapi/cloudmersive.security/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cloudmersive.security"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/cloudmersive.validate/Dependencies.toml
+++ b/openapi/cloudmersive.validate/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cloudmersive.validate"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/cloudmersive.virusscan/Dependencies.toml
+++ b/openapi/cloudmersive.virusscan/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cloudmersive.virusscan"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/constantcontact/Dependencies.toml
+++ b/openapi/constantcontact/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "constantcontact"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/covid19/Dependencies.toml
+++ b/openapi/covid19/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "covid19"
-version = "1.0.0-SNAPSHOT"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/dataflowkit/Dependencies.toml
+++ b/openapi/dataflowkit/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "dataflowkit"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/dev.to/Dependencies.toml
+++ b/openapi/dev.to/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "dev.to"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/dracoon.public/Dependencies.toml
+++ b/openapi/dracoon.public/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "dracoon.public"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/earthref.fiesta/Dependencies.toml
+++ b/openapi/earthref.fiesta/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "earthref.fiesta"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ebay.account/Dependencies.toml
+++ b/openapi/ebay.account/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ebay.account"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ebay.analytics/Dependencies.toml
+++ b/openapi/ebay.analytics/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ebay.analytics"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ebay.browse/Dependencies.toml
+++ b/openapi/ebay.browse/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ebay.browse"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ebay.compliance/Dependencies.toml
+++ b/openapi/ebay.compliance/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ebay.compliance"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ebay.finances/Dependencies.toml
+++ b/openapi/ebay.finances/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ebay.finances"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ebay.inventory/Dependencies.toml
+++ b/openapi/ebay.inventory/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ebay.inventory"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ebay.listing/Dependencies.toml
+++ b/openapi/ebay.listing/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ebay.listing"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/ebay.logistics/Dependencies.toml
+++ b/openapi/ebay.logistics/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ebay.logistics"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/ebay.metadata/Dependencies.toml
+++ b/openapi/ebay.metadata/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ebay.metadata"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ebay.negotiation/Dependencies.toml
+++ b/openapi/ebay.negotiation/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ebay.negotiation"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ebay.recommendation/Dependencies.toml
+++ b/openapi/ebay.recommendation/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ebay.recommendation"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/elmah/Dependencies.toml
+++ b/openapi/elmah/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "elmah"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/exchangerates/Dependencies.toml
+++ b/openapi/exchangerates/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "exchangerates"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/extpose/Dependencies.toml
+++ b/openapi/extpose/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "extpose"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/figshare/Dependencies.toml
+++ b/openapi/figshare/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "figshare"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/files.com/Dependencies.toml
+++ b/openapi/files.com/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "files.com"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/flatapi/Dependencies.toml
+++ b/openapi/flatapi/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "flatapi"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/fraudlabspro.frauddetection/Dependencies.toml
+++ b/openapi/fraudlabspro.frauddetection/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "fraudlabspro.frauddetection"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/fraudlabspro.smsverification/Dependencies.toml
+++ b/openapi/fraudlabspro.smsverification/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "fraudlabspro.smsverification"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/fungenerators.barcode/Dependencies.toml
+++ b/openapi/fungenerators.barcode/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "fungenerators.barcode"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/fungenerators.uuid/Dependencies.toml
+++ b/openapi/fungenerators.uuid/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "fungenerators.uuid"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/giphy/Dependencies.toml
+++ b/openapi/giphy/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "giphy"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/gitlab/Dependencies.toml
+++ b/openapi/gitlab/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "gitlab"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/godaddy.abuse/Dependencies.toml
+++ b/openapi/godaddy.abuse/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "godaddy.abuse"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/godaddy.aftermarket/Dependencies.toml
+++ b/openapi/godaddy.aftermarket/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "godaddy.aftermarket"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/godaddy.agreements/Dependencies.toml
+++ b/openapi/godaddy.agreements/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "godaddy.agreements"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/godaddy.certificates/Dependencies.toml
+++ b/openapi/godaddy.certificates/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "godday.certificates"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/godaddy.countries/Dependencies.toml
+++ b/openapi/godaddy.countries/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "godaddy.countries"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/godaddy.domains/Dependencies.toml
+++ b/openapi/godaddy.domains/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "godaddy.domains"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/godaddy.orders/Dependencies.toml
+++ b/openapi/godaddy.orders/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "godaddy.orders"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/godaddy.shoppers/Dependencies.toml
+++ b/openapi/godaddy.shoppers/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "godaddy.shopper"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/godaddy.subscriptions/Dependencies.toml
+++ b/openapi/godaddy.subscriptions/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "godaddy.subscriptions"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.abusiveexperiencereport/Dependencies.toml
+++ b/openapi/googleapis.abusiveexperiencereport/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.abusiveexperiencereport"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.appsscript/Dependencies.toml
+++ b/openapi/googleapis.appsscript/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.appsscript"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.bigquery.datatransfer/Dependencies.toml
+++ b/openapi/googleapis.bigquery.datatransfer/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.bigquery.datatransfer"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.bigquery/Dependencies.toml
+++ b/openapi/googleapis.bigquery/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.bigquery"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.blogger/Dependencies.toml
+++ b/openapi/googleapis.blogger/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.blogger"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.books/Dependencies.toml
+++ b/openapi/googleapis.books/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.books"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.classroom/Dependencies.toml
+++ b/openapi/googleapis.classroom/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.classroom"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.cloudbillingaccount/Dependencies.toml
+++ b/openapi/googleapis.cloudbillingaccount/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.cloudbillingaccount"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.cloudbuild/Dependencies.toml
+++ b/openapi/googleapis.cloudbuild/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.cloudbuild"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.clouddatastore/Dependencies.toml
+++ b/openapi/googleapis.clouddatastore/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.clouddatastore"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.cloudfilestore/Dependencies.toml
+++ b/openapi/googleapis.cloudfilestore/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.cloudfilestore"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.cloudfunctions/Dependencies.toml
+++ b/openapi/googleapis.cloudfunctions/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.cloudfunctions"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.cloudpubsub/Dependencies.toml
+++ b/openapi/googleapis.cloudpubsub/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.cloudpubsub"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.cloudscheduler/Dependencies.toml
+++ b/openapi/googleapis.cloudscheduler/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.cloudscheduler"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.cloudtalentsolution/Dependencies.toml
+++ b/openapi/googleapis.cloudtalentsolution/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.cloudtalentsolution"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.cloudtranslation/Dependencies.toml
+++ b/openapi/googleapis.cloudtranslation/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.cloudtranslation"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.discovery/Dependencies.toml
+++ b/openapi/googleapis.discovery/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.discovery"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.docs/Dependencies.toml
+++ b/openapi/googleapis.docs/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.docs"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.manufacturercenter/Dependencies.toml
+++ b/openapi/googleapis.manufacturercenter/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.manufacturercenter"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.mybusiness/Dependencies.toml
+++ b/openapi/googleapis.mybusiness/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.mybusiness"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.naturallanguage/Dependencies.toml
+++ b/openapi/googleapis.naturallanguage/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.cloudnaturallanguage"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.oauth2/Dependencies.toml
+++ b/openapi/googleapis.oauth2/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.oauth2"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.retail/Dependencies.toml
+++ b/openapi/googleapis.retail/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.retail"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/googleapis.slides/Dependencies.toml
+++ b/openapi/googleapis.slides/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.slides"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.tasks/Dependencies.toml
+++ b/openapi/googleapis.tasks/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.tasks"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.vault/Dependencies.toml
+++ b/openapi/googleapis.vault/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.vault"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.vision/Dependencies.toml
+++ b/openapi/googleapis.vision/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.vision"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.youtube.analytics/Dependencies.toml
+++ b/openapi/googleapis.youtube.analytics/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.youtube.analytics"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.youtube.data/Dependencies.toml
+++ b/openapi/googleapis.youtube.data/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.youtube.data"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/googleapis.youtube.reporting/Dependencies.toml
+++ b/openapi/googleapis.youtube.reporting/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.youtube.reporting"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/gotomeeting/Dependencies.toml
+++ b/openapi/gotomeeting/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "gotomeeting"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/gototraining/Dependencies.toml
+++ b/openapi/gototraining/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "gototraining"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/gotowebinar/Dependencies.toml
+++ b/openapi/gotowebinar/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "gotowebinar"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/graphhopper.directions/Dependencies.toml
+++ b/openapi/graphhopper.directions/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "graphhopper.directions"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/hubspot.analytics/Dependencies.toml
+++ b/openapi/hubspot.analytics/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.analytics"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/hubspot.crm.companies/Dependencies.toml
+++ b/openapi/hubspot.crm.companies/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.company"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.crm.contacts/Dependencies.toml
+++ b/openapi/hubspot.crm.contacts/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.contact"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.crm.deals/Dependencies.toml
+++ b/openapi/hubspot.crm.deals/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.deal"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.crm.feedback/Dependencies.toml
+++ b/openapi/hubspot.crm.feedback/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.feedback"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/hubspot.crm.imports/Dependencies.toml
+++ b/openapi/hubspot.crm.imports/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.import"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.crm.lineitems/Dependencies.toml
+++ b/openapi/hubspot.crm.lineitems/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.lineitem"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.crm.pipelines/Dependencies.toml
+++ b/openapi/hubspot.crm.pipelines/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.pipeline"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.crm.products/Dependencies.toml
+++ b/openapi/hubspot.crm.products/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.product"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.crm.properties/Dependencies.toml
+++ b/openapi/hubspot.crm.properties/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.property"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.crm.quotes/Dependencies.toml
+++ b/openapi/hubspot.crm.quotes/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.quote"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/hubspot.crm.schemas/Dependencies.toml
+++ b/openapi/hubspot.crm.schemas/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.schema"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.crm.tickets/Dependencies.toml
+++ b/openapi/hubspot.crm.tickets/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.ticket"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.events/Dependencies.toml
+++ b/openapi/hubspot.events/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.events"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.files/Dependencies.toml
+++ b/openapi/hubspot.files/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.files"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/hubspot.marketing/Dependencies.toml
+++ b/openapi/hubspot.marketing/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.marketing"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/icons8/Dependencies.toml
+++ b/openapi/icons8/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "icons8"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/interzoid.convertcurrency/Dependencies.toml
+++ b/openapi/interzoid.convertcurrency/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "interzoid.convertcurrency"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/interzoid.currencyrate/Dependencies.toml
+++ b/openapi/interzoid.currencyrate/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "interzoid.currencyrate"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/interzoid.globalnumberinfo/Dependencies.toml
+++ b/openapi/interzoid.globalnumberinfo/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "interzoid.globalnumberinfo"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/interzoid.globalpageload/Dependencies.toml
+++ b/openapi/interzoid.globalpageload/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "interzoid.globalpageload"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/interzoid.globaltime/Dependencies.toml
+++ b/openapi/interzoid.globaltime/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "interzoid.globaltime"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/interzoid.mailinfo/Dependencies.toml
+++ b/openapi/interzoid.mailinfo/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "interzoid.emailinfo"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/interzoid.statedata/Dependencies.toml
+++ b/openapi/interzoid.statedata/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "interzoid.statedata"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/interzoid.weatherzip/Dependencies.toml
+++ b/openapi/interzoid.weatherzip/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "interzoid.weatherzip"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/interzoid.zipinfo/Dependencies.toml
+++ b/openapi/interzoid.zipinfo/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "interzoid.zipinfo"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/ip2whois/Dependencies.toml
+++ b/openapi/ip2whois/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ip2whois"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ipgeolocation/Dependencies.toml
+++ b/openapi/ipgeolocation/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ipgeolocation"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/iptwist/Dependencies.toml
+++ b/openapi/iptwist/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "iptwist"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/iris.disputeresponder/Dependencies.toml
+++ b/openapi/iris.disputeresponder/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "iris.disputeresponder"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/iris.esignature/Dependencies.toml
+++ b/openapi/iris.esignature/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "iris.esignature"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/iris.helpdesk/Dependencies.toml
+++ b/openapi/iris.helpdesk/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "iris.helpdesk"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/iris.lead/Dependencies.toml
+++ b/openapi/iris.lead/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "iris.lead"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/iris.merchants/Dependencies.toml
+++ b/openapi/iris.merchants/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "iris.merchants"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/iris.residuals/Dependencies.toml
+++ b/openapi/iris.residuals/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "iris.residuals"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/iris.subscriptions/Dependencies.toml
+++ b/openapi/iris.subscriptions/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "iris.subscriptions"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/isbndb/Dependencies.toml
+++ b/openapi/isbndb/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "isbndb"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/isendpro/Dependencies.toml
+++ b/openapi/isendpro/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "isendpro"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/jira/Dependencies.toml
+++ b/openapi/jira/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "jira"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/journey.io/Dependencies.toml
+++ b/openapi/journey.io/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "journey.io"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/kinto/Dependencies.toml
+++ b/openapi/kinto/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "kinto"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/leanix.integrationapi/Dependencies.toml
+++ b/openapi/leanix.integrationapi/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "leanix.integrationapi"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/livestorm/Dependencies.toml
+++ b/openapi/livestorm/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "livestorm"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/logoraisr/Dependencies.toml
+++ b/openapi/logoraisr/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "logoraisr"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/mailchimp/Dependencies.toml
+++ b/openapi/mailchimp/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mailchimp"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/mailscript/Dependencies.toml
+++ b/openapi/mailscript/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mailscript"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/mathtools.numbers/Dependencies.toml
+++ b/openapi/mathtools.numbers/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mathtools.numbers"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/medium/Dependencies.toml
+++ b/openapi/medium/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "medium"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/microsoft.dynamics365businesscentral/Dependencies.toml
+++ b/openapi/microsoft.dynamics365businesscentral/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "microsoft.dynamics365businesscentral"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/mitto.sms/Dependencies.toml
+++ b/openapi/mitto.sms/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mitto.sms"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/namsor/Dependencies.toml
+++ b/openapi/namsor/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "namsor"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/neutrino/Dependencies.toml
+++ b/openapi/neutrino/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "neutrino"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/newsapi/Dependencies.toml
+++ b/openapi/newsapi/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "newsapi"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/notion/Dependencies.toml
+++ b/openapi/notion/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "notion"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/nowpayments/Dependencies.toml
+++ b/openapi/nowpayments/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nowpayments"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/nytimes.archive/Dependencies.toml
+++ b/openapi/nytimes.archive/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nytimes.archive"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/nytimes.articlesearch/Dependencies.toml
+++ b/openapi/nytimes.articlesearch/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nytimes.articlesearch"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/nytimes.books/Dependencies.toml
+++ b/openapi/nytimes.books/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nytimes.books"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/nytimes.mostpopular/Dependencies.toml
+++ b/openapi/nytimes.mostpopular/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nytimes.mostpopular"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/nytimes.moviereviews/Dependencies.toml
+++ b/openapi/nytimes.moviereviews/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nytimes.moviereviews"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/nytimes.newswire/Dependencies.toml
+++ b/openapi/nytimes.newswire/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nytimes.newswire"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/nytimes.semantic/Dependencies.toml
+++ b/openapi/nytimes.semantic/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nytimes.semantic"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/nytimes.timestag/Dependencies.toml
+++ b/openapi/nytimes.timestag/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nytimes.timestags"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/nytimes.topstories/Dependencies.toml
+++ b/openapi/nytimes.topstories/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nytimes.topstories"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/ocpi/Dependencies.toml
+++ b/openapi/ocpi/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ocpi"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/odweather/Dependencies.toml
+++ b/openapi/odweather/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "odweather"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/onepassword/Dependencies.toml
+++ b/openapi/onepassword/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "onepassword"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/openair/Dependencies.toml
+++ b/openapi/openair/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "openair"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/opendesign/Dependencies.toml
+++ b/openapi/opendesign/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "opendesign"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/openfigi/Dependencies.toml
+++ b/openapi/openfigi/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "openfigi"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/openweathermap/Dependencies.toml
+++ b/openapi/openweathermap/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "openweathermap"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/optirtc.public/Dependencies.toml
+++ b/openapi/optirtc.public/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "optirtc.public"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/optitune/Dependencies.toml
+++ b/openapi/optitune/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "optitune"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/orbitcrm/Dependencies.toml
+++ b/openapi/orbitcrm/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "orbitcrm"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/owler/Dependencies.toml
+++ b/openapi/owler/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "owler"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/pagerduty/Dependencies.toml
+++ b/openapi/pagerduty/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "pagerduty"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/paylocity/Dependencies.toml
+++ b/openapi/paylocity/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "paylocity"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/pdfbroker/Dependencies.toml
+++ b/openapi/pdfbroker/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "pdfbroker"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/pipedrive/Dependencies.toml
+++ b/openapi/pipedrive/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "pipedrive"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/plaid/Dependencies.toml
+++ b/openapi/plaid/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "plaid"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/pocketsmith/Dependencies.toml
+++ b/openapi/pocketsmith/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "pocketsmith"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/powertoolsdeveloper.collections/Dependencies.toml
+++ b/openapi/powertoolsdeveloper.collections/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "powertoolsdeveloper.collections"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/powertoolsdeveloper.data/Dependencies.toml
+++ b/openapi/powertoolsdeveloper.data/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "powertoolsdeveloper.data"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/powertoolsdeveloper.datetime/Dependencies.toml
+++ b/openapi/powertoolsdeveloper.datetime/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "powertoolsdeveloper.datetime"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/powertoolsdeveloper.files/Dependencies.toml
+++ b/openapi/powertoolsdeveloper.files/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "powertoolsdeveloper.files"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/powertoolsdeveloper.finance/Dependencies.toml
+++ b/openapi/powertoolsdeveloper.finance/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "powertoolsdeveloper.finance"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/powertoolsdeveloper.math/Dependencies.toml
+++ b/openapi/powertoolsdeveloper.math/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "powertoolsdeveloper.math"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/powertoolsdeveloper.text/Dependencies.toml
+++ b/openapi/powertoolsdeveloper.text/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "powertoolsdeveloper.text"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/powertoolsdeveloper.weather/Dependencies.toml
+++ b/openapi/powertoolsdeveloper.weather/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "powertoolsdeveloper.weather"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/prodpad/Dependencies.toml
+++ b/openapi/prodpad/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "prodpad"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/pushcut/Dependencies.toml
+++ b/openapi/pushcut/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "pushcut"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/readme/Dependencies.toml
+++ b/openapi/readme/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "readme"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/recurly/Dependencies.toml
+++ b/openapi/recurly/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "recurly"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ritekit/Dependencies.toml
+++ b/openapi/ritekit/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ritekit"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/rumble.run/Dependencies.toml
+++ b/openapi/rumble.run/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "rumble.run"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/sakari/Dependencies.toml
+++ b/openapi/sakari/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "sakari"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/samcart/Dependencies.toml
+++ b/openapi/samcart/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "samcart"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/saps4hana.itcm.accountreceivable/Dependencies.toml
+++ b/openapi/saps4hana.itcm.accountreceivable/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "saps4hana.itcm.accountreceivable"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/saps4hana.itcm.agreement/Dependencies.toml
+++ b/openapi/saps4hana.itcm.agreement/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "saps4hana.itcm.agreement"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/saps4hana.itcm.currency/Dependencies.toml
+++ b/openapi/saps4hana.itcm.currency/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "saps4hana.itcm.currency"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/saps4hana.itcm.customer/Dependencies.toml
+++ b/openapi/saps4hana.itcm.customer/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "saps4hana.itcm.customer"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/saps4hana.itcm.customerhierarchy/Dependencies.toml
+++ b/openapi/saps4hana.itcm.customerhierarchy/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "saps4hana.itcm.customerhierarchy"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/saps4hana.itcm.organizationaldata/Dependencies.toml
+++ b/openapi/saps4hana.itcm.organizationaldata/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "saps4hana.itcm.organizationaldata"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/saps4hana.itcm.product/Dependencies.toml
+++ b/openapi/saps4hana.itcm.product/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "saps4hana.itcm.product"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/saps4hana.itcm.producthierarchy/Dependencies.toml
+++ b/openapi/saps4hana.itcm.producthierarchy/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "saps4hana.itcm.producthierarchy"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/saps4hana.itcm.promotion/Dependencies.toml
+++ b/openapi/saps4hana.itcm.promotion/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "saps4hana.itcm.promotion"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/saps4hana.itcm.uom/Dependencies.toml
+++ b/openapi/saps4hana.itcm.uom/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "saps4hana.itcm.uom"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/saps4hana.itcm.user/Dependencies.toml
+++ b/openapi/saps4hana.itcm.user/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "saps4hana.itcm.user"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/selz/Dependencies.toml
+++ b/openapi/selz/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "selz"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/sendgrid/Dependencies.toml
+++ b/openapi/sendgrid/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "sendgrid"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/servicenow/Dependencies.toml
+++ b/openapi/servicenow/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "servicenow"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/shippit/Dependencies.toml
+++ b/openapi/shippit/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "shippit"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/shipwire.carrier/Dependencies.toml
+++ b/openapi/shipwire.carrier/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "shipwire.carrier"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/shipwire.containers/Dependencies.toml
+++ b/openapi/shipwire.containers/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "shipwire.containers"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/shipwire.receivings/Dependencies.toml
+++ b/openapi/shipwire.receivings/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "shipwire.receivings"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/shipwire.warehouse/Dependencies.toml
+++ b/openapi/shipwire.warehouse/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "shipwire.warehouse"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/shorten.rest/Dependencies.toml
+++ b/openapi/shorten.rest/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "shorten.rest"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/siemens.platformcore.identitymanagement/Dependencies.toml
+++ b/openapi/siemens.platformcore.identitymanagement/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "siemens.platformcore.identitymanagement"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/sinch.conversation/Dependencies.toml
+++ b/openapi/sinch.conversation/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "sinch.conversation"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/sinch.sms/Dependencies.toml
+++ b/openapi/sinch.sms/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "sinch.sms"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/sinch.verification/Dependencies.toml
+++ b/openapi/sinch.verification/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "sinch.verification"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/sinch.voice/Dependencies.toml
+++ b/openapi/sinch.voice/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "sinch.voice"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/soundcloud/Dependencies.toml
+++ b/openapi/soundcloud/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "soundcloud"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/spotify/Dependencies.toml
+++ b/openapi/spotify/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "spotify"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/spotto/Dependencies.toml
+++ b/openapi/spotto/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "spotto"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/storecove/Dependencies.toml
+++ b/openapi/storecove/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "storecove"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/stripe/Dependencies.toml
+++ b/openapi/stripe/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "stripe"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/symantotextanalytics/Dependencies.toml
+++ b/openapi/symantotextanalytics/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "symantotextanalytics"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/techport/Dependencies.toml
+++ b/openapi/techport/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "techport"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/themoviedb/Dependencies.toml
+++ b/openapi/themoviedb/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "themoviedb"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/trello/Dependencies.toml
+++ b/openapi/trello/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "trello"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/uber/Dependencies.toml
+++ b/openapi/uber/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "uber"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/vimeo/Dependencies.toml
+++ b/openapi/vimeo/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "vimeo"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/visiblethread/Dependencies.toml
+++ b/openapi/visiblethread/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "visiblethread"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/vonage.numberinsight/Dependencies.toml
+++ b/openapi/vonage.numberinsight/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "vonage.numberinsight"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/vonage.numbers/Dependencies.toml
+++ b/openapi/vonage.numbers/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "vonage.numbers"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/vonage.sms/Dependencies.toml
+++ b/openapi/vonage.sms/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "vonage.sms"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/vonage.verify/Dependencies.toml
+++ b/openapi/vonage.verify/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "vonage.verify"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/vonage.voice/Dependencies.toml
+++ b/openapi/vonage.voice/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "vonage.voice"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/webscraping.ai/Dependencies.toml
+++ b/openapi/webscraping.ai/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "webscraping.ai"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/whatsapp.business/Dependencies.toml
+++ b/openapi/whatsapp.business/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "whatsapp.business"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/wordnik/Dependencies.toml
+++ b/openapi/wordnik/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "wordnik"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/wordpress/Dependencies.toml
+++ b/openapi/wordpress/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "wordpress"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/worldbank/Dependencies.toml
+++ b/openapi/worldbank/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "worldbank"
-version = "1.0.0-SNAPSHOT"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/worldtimeapi/Dependencies.toml
+++ b/openapi/worldtimeapi/Dependencies.toml
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "worldtimeapi"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerinai", name = "observe"}

--- a/openapi/xero.accounts/Dependencies.toml
+++ b/openapi/xero.accounts/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "xero.accounts"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/xero.assets/Dependencies.toml
+++ b/openapi/xero.assets/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "xero.assets"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/xero.bankfeeds/Dependencies.toml
+++ b/openapi/xero.bankfeeds/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "xero.bankfeeds"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/xero.files/Dependencies.toml
+++ b/openapi/xero.files/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "xero.files"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/xero.finance/Dependencies.toml
+++ b/openapi/xero.finance/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "xero.finance"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/xero.projects/Dependencies.toml
+++ b/openapi/xero.projects/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "xero.projects"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/ynab/Dependencies.toml
+++ b/openapi/ynab/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ynab"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/yodlee/Dependencies.toml
+++ b/openapi/yodlee/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "yodlee"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/openapi/zendesk.support/Dependencies.toml
+++ b/openapi/zendesk.support/Dependencies.toml
@@ -274,7 +274,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "zendesk.support"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/zoom/Dependencies.toml
+++ b/openapi/zoom/Dependencies.toml
@@ -277,7 +277,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "zoom"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},


### PR DESCRIPTION
# Description
With SLBeta3 release, all the openapi connector versions will be `1.0.0`
The Dependencies.toml has to be updated with `1.0.0`

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 