### PR TITLE
Fixing godaddy.certificates connector naming issue in Ballerina.toml

### DIFF
--- a/openapi/godaddy.certificates/Ballerina.toml
+++ b/openapi/godaddy.certificates/Ballerina.toml
@@ -2,7 +2,7 @@
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Paid"]
 org = "ballerinax"
-name = "godday.certificates"
+name = "godaddy.certificates"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
 version = "1.0.1-SNAPSHOT"
 authors = ["Ballerina"]


### PR DESCRIPTION
# Description
Fixing the wrong module name in ballerina.toml

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Ballerina Version: Ballerina Swan Lake Beta3
* Operating System: Ubuntu
* Java SDK: Java 11

# Checklist:

### Changes to OpenAPI definition

- [x] Modified `info` section of the OpenAPI definition file - [Example](https://github.com/ballerina-platform/ballerina-extended-library/discussions/74)

    - `description` - what the connector is about 
    - `x-ballerina-init-description` OpenAPI extension - connector initialization details 
    - `x-ballerina-display` OpenAPI extension - connector name and path to the connector icon 

- [x] Added proper description each API Key, if API Key authentication is defined in OpenAPI definition file 

### Changes to connector module

- [x] Added license header at the top of each .bal file. 
- [x] Added Package.md as per the guide [here](https://github.com/ballerina-platform/ballerina-extended-library/discussions/77)
- [x] Added Module.md for the module of the  connector as per the guide [here](https://github.com/ballerina-platform/ballerina-extended-library/discussions/78)
- [x] Created a directory called `resources` at the root of the connector and copied the connector icon there. 
      Name of the icon file need to be `<connector-name>.svg`
- [x] Added Ballerina.toml file with following information. For keywords refer to [guide](https://github.com/ballerina-platform/ballerina-extended-library/discussions/72)

### Verifying connector module

- [x] Compiled the connector successfully with the targeted ballerina version. 
- [x] Conducted smoke tests on the connector (Recommended when OpenAPI definition is obtain from an unofficial source)

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 